### PR TITLE
Fix TimeSerie attributes crashing during copy

### DIFF
--- a/toolbox/api/datagalaxy_api_workspaces.py
+++ b/toolbox/api/datagalaxy_api_workspaces.py
@@ -135,6 +135,15 @@ class DataGalaxyPathWithType:
     path_type: str
 
 
+def handle_timeserie(property: dict) -> dict:
+    # Temporary solution: only copy the latest value of the TimeSerie
+    for key, value in property.items():
+        if isinstance(value, dict):
+            if 'lastEntry' in value:
+                # Expected format : "Date::Value"
+                property[key] = f"{value['lastEntry']['date']}::{value['lastEntry']['value']}"
+
+
 def to_bulk_tree(properties: list) -> list:
     nodes_map = {}
     for property in properties:
@@ -148,6 +157,7 @@ def to_bulk_tree(properties: list) -> list:
         path = property['path']
         path_type = property['typePath']
         del_useless_keys(property)
+        handle_timeserie(property)
 
         # TRANSFORM to bulk item
         path_segments = path[1:].split(PATH_SEPARATOR)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #20 

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](../blob/main/CONTRIBUTING.md) ;
- [x] I have read the [Contributor License Agreement (CLA)](../blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md) and understand that the submission of this PR will constitute an  electronic signature of my agreement of the terms and conditions of DataGalaxy's CLA ;
- [x] There is an approved issue describing the change when contributing a new feature ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
TimeSerie attributes are correctly handled to avoid crashing. Unfortunately only the latest value of the TimeSerie is copied, so further developments will be necessary. 

#### Changes proposed in this pull request:
<!--Fill These Bullet Points-->
- New function to handle TimeSerie attributes
