### PR TITLE
Bugfix: copy-dictionary crashing when trying to upsert a source without children

### DIFF
--- a/toolbox/api/datagalaxy_api_dictionary.py
+++ b/toolbox/api/datagalaxy_api_dictionary.py
@@ -125,6 +125,11 @@ class DataGalaxyApiDictionary:
 
         # We need to make a post request for each source tree
         for source_bulk in bulk_tree:
+            # We cannot send a bulktree containing only a source without children (rejected by the API)
+            if 'children' not in source_bulk or len(source_bulk['children']) < 1:
+                logging.warn(f'bulk_upsert_sources_tree - Cannot create a source without children : {source_bulk}')
+                continue
+
             version_id = self.workspace['defaultVersionId']
             headers = {'Authorization': f"Bearer {self.access_token}"}
             response = requests.post(f"{self.url}/sources/bulktree/{version_id}", json=source_bulk,


### PR DESCRIPTION

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](../blob/main/CONTRIBUTING.md) ;
- [x] I have read the [Contributor License Agreement (CLA)](../blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md) and understand that the submission of this PR will constitute an  electronic signature of my agreement of the terms and conditions of DataGalaxy's CLA ;
- [x] There is an approved issue describing the change when contributing a new feature ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Instead of raising an Exception, we simply ignore this source and go to the next one.

#### Changes proposed in this pull request:
<!--Fill These Bullet Points-->
- Add security check before sending API upsert request
