### PR TITLE
Remove old authenticate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ If you want to use Toolbox on Mac or Linux you need to build a binary file follo
 ##### Flags
 - [optional arguments] `-h`, `--help`- show help message  
 - `--url` - URL 
-- `--token` - Integration token 
+- `--token` - Token 
 - `--url-source`- URL source environnement
 - `--url-target` - URL target environnement 
-- `--token-source` - Integration token from source environnement
-- `--token-target` - Integration token from target environnement
+- `--token-source` - Token from source environnement
+- `--token-target` - Token from target environnement
 - `--workspace-source` - Workspace source name
 - `--workspace-target` - Workspace target name
 - `--tag-value` - Filter objects on a specific tag

--- a/tests/test_copy_attributes.py
+++ b/tests/test_copy_attributes.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_attributes import AttributeDataType, DataGalaxyApiAttributes
 from toolbox.commands.copy_attributes import copy_attributes
 from unittest.mock import ANY
@@ -63,10 +62,6 @@ def test_copy_attributes_when_only_one_source_attr_and_duplicates_on_target(mock
     :param mocker:
     :return: raise Exception
     """
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     attributes_list_mock = mocker.patch.object(DataGalaxyApiAttributes, 'list', autospec=True)
     attributes_list_mock.side_effect = list_mock_when_duplicates
     attributes_bulk_create_mock = mocker.patch.object(DataGalaxyApiAttributes, 'bulk_create', autospec=True)
@@ -76,8 +71,8 @@ def test_copy_attributes_when_only_one_source_attr_and_duplicates_on_target(mock
     result = copy_attributes(
             url_source='url_source',
             url_target='url_target',
-            integration_token_source_value='integration_token_source',
-            integration_token_target_value='integration_token_target'
+            token_source='token_source',
+            token_target='token_target'
         )
     assert attributes_list_mock.call_count == 16
     assert attributes_bulk_create_mock.call_count == 1
@@ -91,10 +86,6 @@ def test_copy_attributes_when_no_source_attr(mocker):
     :return: 0
     """
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     attributes_list_mock = mocker.patch.object(DataGalaxyApiAttributes, 'list', autospec=True)
     attributes_list_mock.return_value = []
     attributes_bulk_create_mock = mocker.patch.object(DataGalaxyApiAttributes, 'bulk_create', autospec=True)
@@ -104,8 +95,8 @@ def test_copy_attributes_when_no_source_attr(mocker):
     result = copy_attributes(
         url_source='url_source',
         url_target='url_target',
-        integration_token_source_value='integration_token_source',
-        integration_token_target_value='integration_token_target'
+        token_source='token_source',
+        token_target='token_target'
     )
     # ASSERT / VERIFY
     assert attributes_list_mock.call_count == 8
@@ -120,10 +111,6 @@ def test_copy_attributes_when_many_source_attrs(mocker):
    :return: raise Exception
    """
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     attributes_list_mock = mocker.patch.object(DataGalaxyApiAttributes, 'list', autospec=True)
     attributes_list_mock.side_effect = list_mock_return_many_attr
     attributes_bulk_create_mock = mocker.patch.object(DataGalaxyApiAttributes, 'bulk_create', autospec=True)
@@ -133,8 +120,8 @@ def test_copy_attributes_when_many_source_attrs(mocker):
     result = copy_attributes(
         url_source='url_source',
         url_target='url_target',
-        integration_token_source_value='integration_token_source',
-        integration_token_target_value='integration_token_target'
+        token_source='token_source',
+        token_target='token_target'
     )
     # ASSERT / VERIFY
     assert attributes_list_mock.call_count == 16
@@ -168,21 +155,11 @@ def test_copy_attributes_when_many_source_attrs(mocker):
 
 def test_copy_attributes_when_only_one_source_attr_and_empty_target(mocker):
     """
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
-    result = get_access_token('', '')
-    assert api_authenticate_mock.call_count == 1
-    assert result == 'token'
-
    Scenario 4. error
    :param mocker:
    :return: raise Exception
    """
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     attributes_list_mock = mocker.patch.object(DataGalaxyApiAttributes, 'list', autospec=True)
     attributes_list_mock.side_effect = list_mock_return_one_common_attr
     attributes_bulk_create_mock = mocker.patch.object(DataGalaxyApiAttributes, 'bulk_create', autospec=True)
@@ -192,8 +169,8 @@ def test_copy_attributes_when_only_one_source_attr_and_empty_target(mocker):
     result = copy_attributes(
         url_source='url_source',
         url_target='url_target',
-        integration_token_source_value='integration_token_source',
-        integration_token_target_value='integration_token_target'
+        token_source='token_source',
+        token_target='token_target'
     )
 
     # ASSERT / VERIFY

--- a/tests/test_copy_dataprocessings.py
+++ b/tests/test_copy_dataprocessings.py
@@ -1,7 +1,6 @@
 from toolbox.api.datagalaxy_api_dataprocessings import DataGalaxyApiDataprocessings
 from toolbox.commands.copy_dataprocessings import copy_dataprocessings
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 import pytest as pytest
 
 
@@ -17,10 +16,6 @@ def mock_list_dataprocessings_on_source_workspace(self, workspace_name):
 
 def test_copy_dataprocessings_when_workspace_source_does_not_exist(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_copy_dictionary.py
+++ b/tests/test_copy_dictionary.py
@@ -1,7 +1,6 @@
 from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
 from toolbox.commands.copy_dictionary import copy_dictionary
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 import pytest as pytest
 
 
@@ -17,10 +16,6 @@ def mock_list_sources_on_source_workspace(self, workspace_name):
 
 def test_copy_sources_when_workspace_source_does_not_exist(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_copy_glossary.py
+++ b/tests/test_copy_glossary.py
@@ -1,7 +1,7 @@
 from toolbox.api.datagalaxy_api_glossary import DataGalaxyApiGlossary
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 from toolbox.commands.copy_glossary import copy_glossary
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 import pytest as pytest
 
 
@@ -17,10 +17,6 @@ def mock_list_properties_on_source_workspace(self, workspace_name):
 
 def test_copy_glossary_when_no_property_on_target(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source', 'workspace_target']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
@@ -62,62 +58,8 @@ def test_copy_glossary_when_no_property_on_target(mocker):
     assert bulk_upsert_properties_on_target_workspace_mock.call_count == 1
 
 
-def test_copy_glossary_same_client_space(mocker):
-    # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
-    workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
-    workspaces.return_value = ['workspace_source', 'workspace_target']
-    workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
-    workspace_source_mock.return_value = 'workspace_source'
-    glossary_properties_on_source_workspace_mock = mocker.patch.object(
-        DataGalaxyApiGlossary,
-        'list_properties',
-        autospec=True)
-    glossary_properties_on_source_workspace_mock.side_effect = mock_list_properties_on_source_workspace
-    bulk_upsert_properties_on_target_workspace_mock = mocker.patch.object(
-        DataGalaxyApiGlossary,
-        'bulk_upsert_property_tree',
-        autospec=True
-    )
-    bulk_upsert_properties_on_target_workspace_mock.return_value = DataGalaxyBulkResult(
-        total=3,
-        created=3,
-        updated=0,
-        unchanged=0,
-        deleted=0
-    )
-
-    # THEN
-
-    copy_glossary(
-        url_source='url_source',
-        token_source='token_source',
-        url_target=None,
-        token_target=None,
-        workspace_source_name='workspace_source',
-        workspace_target_name='workspace_target',
-        tag_value=None
-    )
-
-    # ASSERT / VERIFY
-    assert api_authenticate_mock.call_count == 2
-    api_authenticate_first_call = api_authenticate_mock.call_args_list[0].args[0]
-    api_authenticate_second_call = api_authenticate_mock.call_args_list[1].args[0]
-    assert api_authenticate_first_call.datagalaxy_api.url == 'url_source'
-    assert api_authenticate_first_call.datagalaxy_api.token.value == 'token_source'
-    assert api_authenticate_second_call.datagalaxy_api.url == 'url_source'
-    assert api_authenticate_second_call.datagalaxy_api.token.value == 'token_source'
-
-
 def test_copy_glossary_when_workspace_target_does_not_exist(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_copy_links.py
+++ b/tests/test_copy_links.py
@@ -1,6 +1,5 @@
 from toolbox.commands.copy_links import copy_links
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 import pytest as pytest
 
 
@@ -16,10 +15,6 @@ def mock_list_links_on_source_workspace(self, workspace_name):
 
 def test_copy_links_when_workspace_source_does_not_exist(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_copy_screens.py
+++ b/tests/test_copy_screens.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_screens import DataGalaxyApiScreen
 from toolbox.commands.copy_screens import copy_screens
 import pytest as pytest
@@ -10,10 +9,6 @@ def test_copy_screens_when_no_screen(mocker):
     :param mocker:
     :return: raise Exception
     """
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     source_screens_list_mock = mocker.patch.object(DataGalaxyApiScreen, 'list_screens', autospec=True)
     source_screens_list_mock.return_value = []
 

--- a/tests/test_copy_technologies.py
+++ b/tests/test_copy_technologies.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_technologies import DataGalaxyApiTechnology
 from toolbox.commands.copy_technologies import copy_technologies
 import pytest as pytest
@@ -18,10 +17,6 @@ def test_copy_technologies_when_nothing_on_source(mocker):
     :param mocker:
     :return: raise Exception
     """
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     technologies_list_mock = mocker.patch.object(DataGalaxyApiTechnology, 'list_technologies', autospec=True)
     technologies_list_mock.return_value = []
 
@@ -30,8 +25,8 @@ def test_copy_technologies_when_nothing_on_source(mocker):
         copy_technologies(
             url_source='url_source',
             url_target='url_target',
-            integration_token_source_value='integration_token_source',
-            integration_token_target_value='integration_token_target'
+            token_source='token_source',
+            token_target='token_target'
         )
 
 
@@ -41,10 +36,6 @@ def test_copy_technologies_when_no_custom_technology_on_source(mocker):
     :param mocker:
     :return: raise Exception
     """
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     technologies_list_mock = mocker.patch.object(DataGalaxyApiTechnology, 'list_technologies', autospec=True)
     technologies_list_mock.return_value = list_mock_technologies_without_custom()
 
@@ -52,8 +43,8 @@ def test_copy_technologies_when_no_custom_technology_on_source(mocker):
     result = copy_technologies(
             url_source='url_source',
             url_target='url_target',
-            integration_token_source_value='integration_token_source',
-            integration_token_target_value='integration_token_target'
+            token_source='token_source',
+            token_target='token_target'
         )
 
     assert result == 0

--- a/tests/test_copy_usages.py
+++ b/tests/test_copy_usages.py
@@ -1,7 +1,7 @@
 from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
 from toolbox.commands.copy_usages import copy_usages
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 import pytest as pytest
 
 
@@ -17,10 +17,6 @@ def mock_list_usages_on_source_workspace(self, workspace_name):
 
 def test_copy_usages_when_no_usage_on_target(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source', 'workspace_target']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
@@ -62,63 +58,8 @@ def test_copy_usages_when_no_usage_on_target(mocker):
     assert bulk_upsert_usages_on_target_workspace_mock.call_count == 1
 
 
-def test_copy_usages_same_client_space(mocker):
-    # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
-    workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
-    workspaces.return_value = ['workspace_source', 'workspace_target']
-    workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
-    workspace_source_mock.return_value = 'workspace_source'
-    usages_on_source_workspace_mock = mocker.patch.object(
-        DataGalaxyApiUsages,
-        'list_usages',
-        autospec=True
-    )
-    usages_on_source_workspace_mock.side_effect = mock_list_usages_on_source_workspace
-    bulk_upsert_usages_on_target_workspace_mock = mocker.patch.object(
-        DataGalaxyApiUsages,
-        'bulk_upsert_usages_tree',
-        autospec=True
-    )
-    bulk_upsert_usages_on_target_workspace_mock.return_value = DataGalaxyBulkResult(
-        total=3,
-        created=3,
-        updated=0,
-        unchanged=0,
-        deleted=0
-    )
-
-    # THEN
-
-    copy_usages(
-        url_source='url_source',
-        token_source='token_source',
-        url_target=None,
-        token_target=None,
-        workspace_source_name='workspace_source',
-        workspace_target_name='workspace_target',
-        tag_value=None
-    )
-
-    # ASSERT / VERIFY
-    assert api_authenticate_mock.call_count == 2
-    api_authenticate_first_call = api_authenticate_mock.call_args_list[0].args[0]
-    api_authenticate_second_call = api_authenticate_mock.call_args_list[1].args[0]
-    assert api_authenticate_first_call.datagalaxy_api.url == 'url_source'
-    assert api_authenticate_first_call.datagalaxy_api.token.value == 'token_source'
-    assert api_authenticate_second_call.datagalaxy_api.url == 'url_source'
-    assert api_authenticate_second_call.datagalaxy_api.token.value == 'token_source'
-
-
 def test_copy_usages_when_workspace_target_does_not_exist(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_delete_attributes.py
+++ b/tests/test_delete_attributes.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_attributes import AttributeDataType, DataGalaxyApiAttributes
 from toolbox.commands.delete_attributes import delete_attributes
 
@@ -20,18 +19,13 @@ def mock_list_attributes(self, data_type):
 # Scenarios
 def test_delete_attributes(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     attributes_list_mock = mocker.patch.object(DataGalaxyApiAttributes, 'list', autospec=True)
     attributes_list_mock.side_effect = mock_list_attributes
     delete_attributes_mock = mocker.patch.object(DataGalaxyApiAttributes, 'delete_attribute', autospec=True)
     delete_attributes_mock.return_value = True
 
     # THEN
-    result = delete_attributes(url='url',
-                               integration_token_value='token')
+    result = delete_attributes(url='url', token='token')
 
     # ASSERT / VERIFY
     assert result is True

--- a/tests/test_delete_dataprocessings.py
+++ b/tests/test_delete_dataprocessings.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 from toolbox.api.datagalaxy_api_dataprocessings import DataGalaxyApiDataprocessings
 from toolbox.commands.delete_dataprocessings import delete_dataprocessings
@@ -21,10 +20,6 @@ def mock_list_dataprocessings(self, data_type):
 # Scenarios
 def test_delete_dataprocessings(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_delete_dictionary.py
+++ b/tests/test_delete_dictionary.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
 from toolbox.commands.delete_dictionary import delete_dictionary
@@ -21,10 +20,6 @@ def mock_list_sources(self, data_type):
 # Scenarios
 def test_delete_dictionary(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_delete_glossary.py
+++ b/tests/test_delete_glossary.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 from toolbox.api.datagalaxy_api_glossary import DataGalaxyApiGlossary
 from toolbox.commands.delete_glossary import delete_glossary
@@ -21,10 +20,6 @@ def mock_list_glossary_properties(self, data_type):
 # Scenarios
 def test_delete_glossary(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/tests/test_delete_usages.py
+++ b/tests/test_delete_usages.py
@@ -1,4 +1,3 @@
-from toolbox.api.datagalaxy_api import DataGalaxyApiAuthentication, Token
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
 from toolbox.commands.delete_usages import delete_usages
@@ -21,10 +20,6 @@ def mock_list_usages(self, data_type):
 # Scenarios
 def test_delete_usages(mocker):
     # GIVEN
-    client_space_mock = mocker.patch.object(Token, 'get_client_space_id', autospec=True)
-    client_space_mock.return_value = 'cid'
-    api_authenticate_mock = mocker.patch.object(DataGalaxyApiAuthentication, 'authenticate', autospec=True)
-    api_authenticate_mock.return_value = 'token'
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)

--- a/toolbox/api/datagalaxy_api.py
+++ b/toolbox/api/datagalaxy_api.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-import jwt
-import requests
 import logging
 
 logging.basicConfig(level=logging.INFO,
@@ -10,64 +8,10 @@ logging.basicConfig(level=logging.INFO,
                     )
 
 
-class Token:
-    def __init__(self, value):
-        self.value = value
-
-    def get_client_space_id(self) -> str:
-        decode_token = jwt.decode(
-            self.value,
-            options={"verify_signature": False},
-            algorithms=["HS256"]
-        )
-        # old auth
-        if "cid" in decode_token:
-            client_space_id = decode_token["cid"]
-        # authv2
-        elif "dg_client_id" in decode_token:
-            client_space_id = decode_token["dg_client_id"]
-        else:
-            raise Exception('Error while decoding the token')
-
-        return client_space_id
-
-
 @dataclass
 class DataGalaxyApi:
     url: str
-    token: Token
-
-
-class DataGalaxyApiAuthentication:
-    def __init__(self, datagalaxy_api: DataGalaxyApi):
-        self.datagalaxy_api = datagalaxy_api
-
-    def authenticate(self) -> str:
-        """
-        Generate an access token from the DataGalaxy API.
-
-        Documentation: https://apici.datagalaxy.com/v2/documentation/beta#operation/Generate
-        :return: an access token
-        """
-        headers = {"Authorization": f"Bearer {self.datagalaxy_api.token.value}"}
-        request = requests.get(f"{self.datagalaxy_api.url}/credentials", headers=headers)
-        body_json = request.json()
-        code = request.status_code
-        if code == 200:
-            return body_json['accessToken']
-        elif 400 <= code < 500:
-            raise Exception(body_json['error'])
-        else:
-            raise Exception(f'Unexpected error, code: {code}')
-
-
-def get_access_token(url: str, integration_token: Token):
-    dev_uat_env = DataGalaxyApi(url, integration_token)
-    auth_api = DataGalaxyApiAuthentication(dev_uat_env)
-    access_token = auth_api.authenticate()
-    client_space_id = integration_token.get_client_space_id()
-    logging.info(f'get_access_token - Authenticating [url: {url} , client_space: {client_space_id}]')
-    return access_token
+    token: str
 
 
 @dataclass(frozen=True)

--- a/toolbox/api/datagalaxy_api_attributes.py
+++ b/toolbox/api/datagalaxy_api_attributes.py
@@ -18,13 +18,13 @@ class AttributeDataType(Enum):
 
 
 class DataGalaxyApiAttributes:
-    def __init__(self, url: str, access_token: str):
+    def __init__(self, url: str, token: str):
         self.url = url
-        self.access_token = access_token
+        self.token = token
 
     def list(self, data_type: AttributeDataType, only_custom=True) -> list:
         params = {'dataType': data_type.value.lower()}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         request = requests.get(f"{self.url}/attributes", params=params, headers=headers)
         code = request.status_code
         body_json = request.json()
@@ -42,7 +42,7 @@ class DataGalaxyApiAttributes:
 
     def list_values(self, data_type: str, attribute_key: str) -> list:
         params = {'dataType': data_type.lower(), 'attributeKey': attribute_key}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         request = requests.get(f"{self.url}/attributes/values", params=params, headers=headers)
         code = request.status_code
         body_json = request.json()
@@ -57,7 +57,7 @@ class DataGalaxyApiAttributes:
         bulks = [bulk_attributes[i:i + 50] for i in range(0, len(bulk_attributes), 50)]
 
         for bulk in bulks:
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             logging.debug(f"bulk_create - bulk_create(bulk: {bulk})")
             request = requests.post(f"{self.url}/attributes/bulk", json=bulk, headers=headers)
 
@@ -76,7 +76,7 @@ class DataGalaxyApiAttributes:
         return len(attributes)
 
     def create_attribute(self, attribute: dict) -> dict:
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.post(f"{self.url}/attributes/{attribute['dataType'].lower()}", json=attribute, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -87,7 +87,7 @@ class DataGalaxyApiAttributes:
         return body_json
 
     def create_values(self, data_type: str, attribute_key: str, values: list) -> dict:
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         params = {'dataType': data_type.lower(), 'attributeKey': attribute_key}
         response = requests.post(f"{self.url}/attributes/values", json=values, headers=headers, params=params)
         code = response.status_code
@@ -100,7 +100,7 @@ class DataGalaxyApiAttributes:
 
     def delete_attribute(self, data_type: AttributeDataType, attribute_key: str) -> bool:
         logging.debug(f"delete_attribute- delete_attribute(data_type: {data_type}, attribute_key: {attribute_key})")
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         request = requests.delete(f"{self.url}/attributes/{data_type}/{attribute_key}", headers=headers)
         code = request.status_code
         body_json = request.json()

--- a/toolbox/api/datagalaxy_api_dataprocessings.py
+++ b/toolbox/api/datagalaxy_api_dataprocessings.py
@@ -5,17 +5,17 @@ from typing import Optional
 
 
 class DataGalaxyApiDataprocessings:
-    def __init__(self, url: str, access_token: str, workspace: dict):
+    def __init__(self, url: str, token: str, workspace: dict):
         if workspace["isVersioningEnabled"]:
             raise Exception('Workspace with versioning enabled are currently not supported.')
         self.url = url
-        self.access_token = access_token
+        self.token = token
         self.workspace = workspace
 
     def list_dataprocessings(self, workspace_name: str) -> list:
         version_id = self.workspace['defaultVersionId']
         params = {'versionId': version_id, 'includeAttributes': 'true'}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/dataProcessing", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -28,7 +28,7 @@ class DataGalaxyApiDataprocessings:
         result = result + body_json['results']
         next_page = body_json["next_page"]
         while next_page is not None:
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(next_page, headers=headers)
             body_json = response.json()
             next_page = body_json["next_page"]
@@ -38,7 +38,7 @@ class DataGalaxyApiDataprocessings:
     def list_dataprocessing_items(self, workspace_name: str, parent_id: str) -> list:
         version_id = self.workspace['defaultVersionId']
         params = {'versionId': version_id, 'parentId': parent_id, 'includeAttributes': 'true'}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/dataProcessingItem", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -51,7 +51,7 @@ class DataGalaxyApiDataprocessings:
         result = result + body_json['results']
         next_page = body_json["next_page"]
         while next_page is not None:
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(next_page, headers=headers)
             body_json = response.json()
             next_page = body_json["next_page"]
@@ -73,7 +73,7 @@ class DataGalaxyApiDataprocessings:
                     remove_technology_code(children)
 
         version_id = self.workspace['defaultVersionId']
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.post(f"{self.url}/dataProcessing/bulktree/{version_id}", json=bulk_tree, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -97,7 +97,7 @@ class DataGalaxyApiDataprocessings:
             raise Exception('Versionned workspaces are not supported')
 
         version_id = self.workspace['defaultVersionId']
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.delete(f"{self.url}/dataProcessing/bulk/{version_id}",
                                    json=ids,
                                    headers=headers)

--- a/toolbox/api/datagalaxy_api_dictionary.py
+++ b/toolbox/api/datagalaxy_api_dictionary.py
@@ -5,11 +5,11 @@ from typing import Optional
 
 
 class DataGalaxyApiDictionary:
-    def __init__(self, url: str, access_token: str, workspace: dict):
+    def __init__(self, url: str, token: str, workspace: dict):
         if workspace["isVersioningEnabled"]:
             raise Exception('Workspace with versioning enabled are currently not supported.')
         self.url = url
-        self.access_token = access_token
+        self.token = token
         self.workspace = workspace
 
     def list_sources(self, workspace_name: str, include_links=False) -> list:
@@ -18,7 +18,7 @@ class DataGalaxyApiDictionary:
             params = {'versionId': version_id, 'includeAttributes': 'false', 'includeLinks': 'true'}
         else:
             params = {'versionId': version_id, 'includeAttributes': 'true'}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/sources", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -32,7 +32,7 @@ class DataGalaxyApiDictionary:
         result = result + body_json['results']
         next_page = body_json["next_page"]
         while next_page is not None:
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(next_page, headers=headers)
             body_json = response.json()
             # We can have errors on next page too
@@ -48,7 +48,7 @@ class DataGalaxyApiDictionary:
             params = {'versionId': version_id, 'includeAttributes': 'false', 'includeLinks': 'true'}
         else:
             params = {'versionId': version_id, 'includeAttributes': 'true'}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/containers", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -62,7 +62,7 @@ class DataGalaxyApiDictionary:
         result = result + body_json['results']
         next_page = body_json["next_page"]
         while next_page is not None:
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(next_page, headers=headers)
             body_json = response.json()
             # We can have errors on next page too
@@ -78,7 +78,7 @@ class DataGalaxyApiDictionary:
             params = {'versionId': version_id, 'includeAttributes': 'false', 'includeLinks': 'true'}
         else:
             params = {'versionId': version_id, 'includeAttributes': 'true'}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/structures", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -92,7 +92,7 @@ class DataGalaxyApiDictionary:
         result = result + body_json['results']
         next_page = body_json["next_page"]
         while next_page is not None:
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(next_page, headers=headers)
             body_json = response.json()
             # We can have errors on next page too
@@ -108,7 +108,7 @@ class DataGalaxyApiDictionary:
             params = {'versionId': version_id, 'includeAttributes': 'false', 'includeLinks': 'true'}
         else:
             params = {'versionId': version_id, 'includeAttributes': 'true'}
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/fields", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -122,7 +122,7 @@ class DataGalaxyApiDictionary:
         result = result + body_json['results']
         next_page = body_json["next_page"]
         while next_page is not None:
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(next_page, headers=headers)
             body_json = response.json()
             # We can have errors on next page too
@@ -138,7 +138,7 @@ class DataGalaxyApiDictionary:
             raise Exception('Workspace with versioning enabled are currently not supported.')
 
         version_id = self.workspace['defaultVersionId']
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.post(f"{self.url}/sources/{version_id}", json=source,
                                  headers=headers)
         code = response.status_code
@@ -164,7 +164,7 @@ class DataGalaxyApiDictionary:
                 continue
 
             version_id = self.workspace['defaultVersionId']
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.post(f"{self.url}/sources/bulktree/{version_id}", json=source_bulk,
                                      headers=headers)
             code = response.status_code
@@ -189,7 +189,7 @@ class DataGalaxyApiDictionary:
             raise Exception('Versionned workspaces are not supported')
 
         version_id = self.workspace['defaultVersionId']
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.delete(f"{self.url}/sources/bulk/{version_id}",
                                    json=ids,
                                    headers=headers)

--- a/toolbox/api/datagalaxy_api_glossary.py
+++ b/toolbox/api/datagalaxy_api_glossary.py
@@ -5,9 +5,9 @@ from typing import Optional
 
 
 class DataGalaxyApiGlossary:
-    def __init__(self, url: str, access_token: str, workspace: dict):
+    def __init__(self, url: str, token: str, workspace: dict):
         self.url = url
-        self.access_token = access_token
+        self.token = token
         self.workspace = workspace
 
     def list_properties(self, workspace_name: str, include_links=False) -> list:
@@ -17,7 +17,7 @@ class DataGalaxyApiGlossary:
                 params = {'versionId': version_id, 'includeAttributes': 'false', 'includeLinks': 'true'}
             else:
                 params = {'versionId': version_id, 'includeAttributes': 'true'}
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(f"{self.url}/properties", params=params, headers=headers)
             code = response.status_code
             body_json = response.json()
@@ -29,7 +29,7 @@ class DataGalaxyApiGlossary:
                 result = result + body_json['results']
                 next_page = body_json["next_page"]
                 while next_page is not None:
-                    headers = {'Authorization': f"Bearer {self.access_token}"}
+                    headers = {'Authorization': f"Bearer {self.token}"}
                     response = requests.get(next_page, headers=headers)
                     body_json = response.json()
                     next_page = body_json["next_page"]
@@ -53,7 +53,7 @@ class DataGalaxyApiGlossary:
 
         if not self.workspace["isVersioningEnabled"]:
             version_id = self.workspace['defaultVersionId']
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.post(f"{self.url}/properties/bulktree/{version_id}", json=properties_ok_to_bulk,
                                      headers=headers)
             code = response.status_code
@@ -81,7 +81,7 @@ class DataGalaxyApiGlossary:
             raise Exception('Versionned workspaces are not supported')
 
         version_id = self.workspace['defaultVersionId']
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.delete(f"{self.url}/properties/bulk/{version_id}",
                                    json=ids,
                                    headers=headers)

--- a/toolbox/api/datagalaxy_api_links.py
+++ b/toolbox/api/datagalaxy_api_links.py
@@ -3,9 +3,9 @@ from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 
 
 class DataGalaxyApiLinks:
-    def __init__(self, url: str, access_token: str, workspace: dict):
+    def __init__(self, url: str, token: str, workspace: dict):
         self.url = url
-        self.access_token = access_token
+        self.token = token
         self.workspace = workspace
 
     def bulk_create_links(self, workspace_name: str, links: list) -> DataGalaxyBulkResult:
@@ -14,7 +14,7 @@ class DataGalaxyApiLinks:
             raise Exception('Workspace with versioning enabled are currently not supported.')
 
         version_id = self.workspace['defaultVersionId']
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.post(f"{self.url}/links/bulktree/{version_id}", json=links,
                                  headers=headers)
         code = response.status_code

--- a/toolbox/api/datagalaxy_api_screens.py
+++ b/toolbox/api/datagalaxy_api_screens.py
@@ -3,13 +3,13 @@ from typing import Optional
 
 
 class DataGalaxyApiScreen:
-    def __init__(self, url: str, access_token: str, workspace: Optional[dict]):
+    def __init__(self, url: str, token: str, workspace: Optional[dict]):
         self.url = url
-        self.access_token = access_token
+        self.token = token
         self.workspace = workspace
 
     def list_screens(self) -> list:
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         if self.workspace is None:
             response = requests.get(f"{self.url}/attributes/screens", headers=headers)
         else:
@@ -23,7 +23,7 @@ class DataGalaxyApiScreen:
         return body_json
 
     def update_screen(self, screen) -> object:
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         dataType = screen['dataType'].lower()
         type = screen['type'].lower()
         categories = screen['categories']

--- a/toolbox/api/datagalaxy_api_technologies.py
+++ b/toolbox/api/datagalaxy_api_technologies.py
@@ -3,12 +3,12 @@ import requests as requests
 
 
 class DataGalaxyApiTechnology:
-    def __init__(self, url: str, access_token: str):
+    def __init__(self, url: str, token: str):
         self.url = url
-        self.access_token = access_token
+        self.token = token
 
     def list_technologies(self) -> list:
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/technologies", headers=headers)
         code = response.status_code
         body_json = response.json()
@@ -20,7 +20,7 @@ class DataGalaxyApiTechnology:
         return result
 
     def insert_technology(self, technology) -> object:
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.post(f"{self.url}/technologies", json=technology, headers=headers)
         code = response.status_code
         body_json = response.json()

--- a/toolbox/api/datagalaxy_api_usages.py
+++ b/toolbox/api/datagalaxy_api_usages.py
@@ -5,9 +5,9 @@ from typing import Optional
 
 
 class DataGalaxyApiUsages:
-    def __init__(self, url: str, access_token: str, workspace: dict):
+    def __init__(self, url: str, token: str, workspace: dict):
         self.url = url
-        self.access_token = access_token
+        self.token = token
         self.workspace = workspace
 
     def list_usages(self, workspace_name: str, include_links=False) -> list:
@@ -17,7 +17,7 @@ class DataGalaxyApiUsages:
                 params = {'versionId': version_id, 'includeAttributes': 'false', 'includeLinks': 'true'}
             else:
                 params = {'versionId': version_id, 'includeAttributes': 'true'}
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.get(f"{self.url}/usages", params=params, headers=headers)
             code = response.status_code
             body_json = response.json()
@@ -29,7 +29,7 @@ class DataGalaxyApiUsages:
                 result = result + body_json['results']
                 next_page = body_json["next_page"]
                 while next_page is not None:
-                    headers = {'Authorization': f"Bearer {self.access_token}"}
+                    headers = {'Authorization': f"Bearer {self.token}"}
                     response = requests.get(next_page, headers=headers)
                     body_json = response.json()
                     next_page = body_json["next_page"]
@@ -59,7 +59,7 @@ class DataGalaxyApiUsages:
 
         if not self.workspace["isVersioningEnabled"]:
             version_id = self.workspace['defaultVersionId']
-            headers = {'Authorization': f"Bearer {self.access_token}"}
+            headers = {'Authorization': f"Bearer {self.token}"}
             response = requests.post(f"{self.url}/usages/bulktree/{version_id}", json=usages_ok_to_bulk,
                                      headers=headers)
             code = response.status_code
@@ -86,7 +86,7 @@ class DataGalaxyApiUsages:
             raise Exception('Versionned workspaces are not supported')
 
         version_id = self.workspace['defaultVersionId']
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.delete(f"{self.url}/usages/bulk/{version_id}",
                                    json=ids,
                                    headers=headers)

--- a/toolbox/api/datagalaxy_api_workspaces.py
+++ b/toolbox/api/datagalaxy_api_workspaces.py
@@ -2,12 +2,12 @@ import requests as requests
 
 
 class DataGalaxyApiWorkspace:
-    def __init__(self, url: str, access_token: str):
+    def __init__(self, url: str, token: str):
         self.url = url
-        self.access_token = access_token
+        self.token = token
 
     def list_workspaces(self):
-        headers = {'Authorization': f"Bearer {self.access_token}"}
+        headers = {'Authorization': f"Bearer {self.token}"}
         response = requests.get(f"{self.url}/workspaces", headers=headers)
         code = response.status_code
         body_json = response.json()

--- a/toolbox/commands/copy_attributes.py
+++ b/toolbox/commands/copy_attributes.py
@@ -1,37 +1,28 @@
 import logging
 
-from toolbox.api.datagalaxy_api import get_access_token, Token
 from toolbox.api.datagalaxy_api_attributes import DataGalaxyApiAttributes, custom_attributes, find_duplicates
 
 
 def copy_attributes(url_source: str,
                     url_target: str,
-                    integration_token_source_value: str,
-                    integration_token_target_value: str) -> int:
-    integration_token_source = Token(integration_token_source_value)
-    integration_token_target = Token(integration_token_target_value)
-
-    source_client_space_id = integration_token_source.get_client_space_id()
-    target_client_space_id = integration_token_target.get_client_space_id()
-
-    access_token_source = get_access_token(url_source, integration_token_source)
-    access_token_target = get_access_token(url_target, integration_token_target)
-    attributes_api_source = DataGalaxyApiAttributes(url=url_source, access_token=access_token_source)
-    attributes_api_target = DataGalaxyApiAttributes(url=url_target, access_token=access_token_target)
+                    token_source: str,
+                    token_target: str) -> int:
+    attributes_api_source = DataGalaxyApiAttributes(url=url_source, token=token_source)
+    attributes_api_target = DataGalaxyApiAttributes(url=url_target, token=token_target)
     custom_source_attributes = custom_attributes(attributes_api_source)
     logging.debug(f"copy_attributes - custom_source_attributes: {custom_source_attributes}")
     logging.info(
-        f'copy_attributes - {len(custom_source_attributes)} custom attributes found on source client_space: {source_client_space_id}')
+        f'copy_attributes - {len(custom_source_attributes)} custom attributes found on source client_space')
     if len(custom_source_attributes) == 0:
-        logging.warning(f'copy_attributes - no custom attribute found on client_space: {source_client_space_id}, aborting.')
+        logging.warning('copy_attributes - no custom attribute found on client_space, aborting.')
         return 0
 
     custom_target_attributes = custom_attributes(attributes_api_target)
     logging.info(
-        f'copy_attributes - {len(custom_target_attributes)} custom attributes found on target client_space: {target_client_space_id}')
+        f'copy_attributes - {len(custom_target_attributes)} custom attributes found on target client_space')
 
     duplicates = find_duplicates(custom_source_attributes, custom_target_attributes)
-    logging.warning(f'copy_attributes - {len(duplicates)} duplicates found on client_space: {target_client_space_id}: {duplicates}')
+    logging.warning(f'copy_attributes - {len(duplicates)} duplicates found on target client_space: {duplicates}')
     source_attributes_to_create = list(filter(lambda x: x['name'] not in duplicates, custom_source_attributes))
 
     # These attribute formats require a special behavior : we need to fetch their values and create them in a separate API call
@@ -43,8 +34,7 @@ def copy_attributes(url_source: str,
     # Bulk create attributes that do not have values
     attributes_created_count = attributes_api_target.bulk_create(source_attributes_to_create_without_values)
     logging.info(
-        f'copy_attributes - {attributes_created_count} custom attributes copied from client_space: '
-        f'{source_client_space_id} to client_space: {target_client_space_id}')
+        f'copy_attributes - {attributes_created_count} custom attributes copied from source client_space to target client_space')
 
     for attribute in source_attributes_to_create_with_values:
         format = attribute['format']
@@ -62,8 +52,7 @@ def copy_attributes(url_source: str,
         attributes_api_target.create_values(data_type=data_type, attribute_key=attribute_key, values=values)
 
     logging.info(
-        f'copy_attributes - {len(source_attributes_to_create_with_values)} custom attributes (with values) copied from client_space: '
-        f'{source_client_space_id} to client_space: {target_client_space_id}')
+        f'copy_attributes - {len(source_attributes_to_create_with_values)} custom attributes (with values) copied from client_space to target client_space')
 
     return attributes_created_count
 
@@ -84,10 +73,10 @@ def copy_attributes_parse(subparsers):
     copy_attributes_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration source token',
+        help='source token',
         required=True)
     copy_attributes_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration target token',
+        help='target token',
         required=True)

--- a/toolbox/commands/copy_dataprocessings.py
+++ b/toolbox/commands/copy_dataprocessings.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_dataprocessings import DataGalaxyApiDataprocessings
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 
@@ -19,21 +19,16 @@ def copy_dataprocessings(url_source: str,
     if url_target is None:
         url_target = url_source
 
-    integration_token_source = Token(token_source)
-    integration_token_target = Token(token_target)
-    source_access_token = get_access_token(url_source, integration_token_source)
-    target_access_token = get_access_token(url_target, integration_token_target)
-
     workspaces_api_on_source_env = DataGalaxyApiWorkspace(
         url=url_source,
-        access_token=source_access_token)
+        token=token_source)
     source_workspace = workspaces_api_on_source_env.get_workspace(workspace_source_name)
     if source_workspace is None:
         raise Exception(f'workspace {workspace_source_name} does not exist')
 
     workspaces_api_on_target_env = DataGalaxyApiWorkspace(
         url=url_target,
-        access_token=target_access_token
+        token=token_target
     )
     target_workspace = workspaces_api_on_target_env.get_workspace(workspace_target_name)
     if target_workspace is None:
@@ -41,12 +36,12 @@ def copy_dataprocessings(url_source: str,
 
     source_dataprocessings_api = DataGalaxyApiDataprocessings(
         url=url_source,
-        access_token=source_access_token,
+        token=token_source,
         workspace=source_workspace
     )
     target_dataprocessings_api = DataGalaxyApiDataprocessings(
         url=url_target,
-        access_token=target_access_token,
+        token=token_target,
         workspace=target_workspace
     )
 
@@ -106,7 +101,7 @@ def copy_dataprocessings_parse(subparsers):
     copy_dataprocessings_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration token source environnement',
+        help='token source environnement',
         required=True)
     copy_dataprocessings_parse.add_argument(
         '--url-target',
@@ -115,7 +110,7 @@ def copy_dataprocessings_parse(subparsers):
     copy_dataprocessings_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration token target environnement (if undefined, use token source)')
+        help='token target environnement (if undefined, use token source)')
     copy_dataprocessings_parse.add_argument(
         '--workspace-source',
         type=str,

--- a/toolbox/commands/copy_dictionary.py
+++ b/toolbox/commands/copy_dictionary.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 
@@ -18,14 +18,9 @@ def copy_dictionary(url_source: str,
     if url_target is None:
         url_target = url_source
 
-    integration_token_source = Token(token_source)
-    integration_token_target = Token(token_target)
-    source_access_token = get_access_token(url_source, integration_token_source)
-    target_access_token = get_access_token(url_target, integration_token_target)
-
     workspaces_api_on_source_env = DataGalaxyApiWorkspace(
         url=url_source,
-        access_token=source_access_token
+        token=token_source
     )
     source_workspace = workspaces_api_on_source_env.get_workspace(workspace_source_name)
     if source_workspace is None:
@@ -33,7 +28,7 @@ def copy_dictionary(url_source: str,
 
     workspaces_api_on_target_env = DataGalaxyApiWorkspace(
         url=url_target,
-        access_token=target_access_token
+        token=token_target
     )
     target_workspace = workspaces_api_on_target_env.get_workspace(workspace_target_name)
     if target_workspace is None:
@@ -41,12 +36,12 @@ def copy_dictionary(url_source: str,
 
     dictionary_on_source_workspace = DataGalaxyApiDictionary(
         url=url_source,
-        access_token=source_access_token,
+        token=token_source,
         workspace=workspaces_api_on_source_env.get_workspace(workspace_source_name)
     )
     dictionary_on_target_workspace = DataGalaxyApiDictionary(
         url=url_target,
-        access_token=target_access_token,
+        token=token_target,
         workspace=target_workspace
     )
 
@@ -85,7 +80,7 @@ def copy_dictionary_parse(subparsers):
     copy_dictionary_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration token source environnement',
+        help='token source environnement',
         required=True)
     copy_dictionary_parse.add_argument(
         '--url-target',
@@ -94,7 +89,7 @@ def copy_dictionary_parse(subparsers):
     copy_dictionary_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration token target environnement (if undefined, use token source)')
+        help='token target environnement (if undefined, use token source)')
     copy_dictionary_parse.add_argument(
         '--workspace-source',
         type=str,

--- a/toolbox/commands/copy_glossary.py
+++ b/toolbox/commands/copy_glossary.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_glossary import DataGalaxyApiGlossary
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 
@@ -18,17 +18,13 @@ def copy_glossary(url_source: str,
     if url_target is None:
         url_target = url_source
 
-    integration_token_source = Token(token_source)
-    integration_token_target = Token(token_target)
-    source_access_token = get_access_token(url_source, integration_token_source)
-    target_access_token = get_access_token(url_target, integration_token_target)
     workspaces_api_on_source_env = DataGalaxyApiWorkspace(
         url=url_source,
-        access_token=source_access_token)
+        token=token_source)
 
     workspaces_api_on_target_env = DataGalaxyApiWorkspace(
         url=url_target,
-        access_token=target_access_token
+        token=token_target
     )
 
     workspace_source = workspaces_api_on_source_env.get_workspace(workspace_source_name)
@@ -38,7 +34,7 @@ def copy_glossary(url_source: str,
         # on récupère les propriétés du glossary du workspace_source
         glossary_on_source_workspace = DataGalaxyApiGlossary(
             url=url_source,
-            access_token=source_access_token,
+            token=token_source,
             workspace=workspace_source
         )
         workspace_source_glossary_properties = glossary_on_source_workspace.list_properties(
@@ -47,7 +43,7 @@ def copy_glossary(url_source: str,
         # on copie ces propriétés sur le workspace_target
         glossary_on_target_workspace = DataGalaxyApiGlossary(
             url=url_target,
-            access_token=target_access_token,
+            token=token_target,
             workspace=workspace_target
         )
         return glossary_on_target_workspace.bulk_upsert_property_tree(
@@ -70,7 +66,7 @@ def copy_glossary_parse(subparsers):
     copy_glossary_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration token source environnement',
+        help='token source environnement',
         required=True)
     copy_glossary_parse.add_argument(
         '--url-target',
@@ -79,7 +75,7 @@ def copy_glossary_parse(subparsers):
     copy_glossary_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration token target environnement (if undefined, use token source)')
+        help='token target environnement (if undefined, use token source)')
     copy_glossary_parse.add_argument(
         '--workspace-source',
         type=str,

--- a/toolbox/commands/copy_links.py
+++ b/toolbox/commands/copy_links.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
 from toolbox.api.datagalaxy_api_glossary import DataGalaxyApiGlossary
 from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
@@ -21,20 +21,16 @@ def copy_links(url_source: str,
     if url_target is None:
         url_target = url_source
 
-    integration_token_source = Token(token_source)
-    integration_token_target = Token(token_target)
-    source_access_token = get_access_token(url_source, integration_token_source)
-    target_access_token = get_access_token(url_target, integration_token_target)
     workspaces_api_on_source_env = DataGalaxyApiWorkspace(
         url=url_source,
-        access_token=source_access_token)
+        token=token_source)
     source_workspace = workspaces_api_on_source_env.get_workspace(workspace_source_name)
     if source_workspace is None:
         raise Exception(f'workspace {workspace_source_name} does not exist')
 
     workspaces_api_on_target_env = DataGalaxyApiWorkspace(
         url=url_target,
-        access_token=target_access_token
+        token=token_target
     )
     target_workspace = workspaces_api_on_target_env.get_workspace(workspace_target_name)
     if target_workspace is None:
@@ -42,17 +38,17 @@ def copy_links(url_source: str,
 
     source_usages_api = DataGalaxyApiUsages(
         url=url_source,
-        access_token=source_access_token,
+        token=token_source,
         workspace=source_workspace
     )
     source_glossary_api = DataGalaxyApiGlossary(
         url=url_source,
-        access_token=source_access_token,
+        token=token_source,
         workspace=source_workspace
     )
     source_dictionary_api = DataGalaxyApiDictionary(
         url=url_source,
-        access_token=source_access_token,
+        token=token_source,
         workspace=source_workspace
     )
 
@@ -75,7 +71,7 @@ def copy_links(url_source: str,
 
     target_links_api = DataGalaxyApiLinks(
         url=url_target,
-        access_token=target_access_token,
+        token=token_target,
         workspace=target_workspace
     )
 
@@ -116,7 +112,7 @@ def copy_links_parse(subparsers):
     copy_links_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration token source environnement',
+        help='token source environnement',
         required=True)
     copy_links_parse.add_argument(
         '--url-target',
@@ -125,7 +121,7 @@ def copy_links_parse(subparsers):
     copy_links_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration token target environnement (if undefined, use token source)')
+        help='token target environnement (if undefined, use token source)')
     copy_links_parse.add_argument(
         '--workspace-source',
         type=str,

--- a/toolbox/commands/copy_screens.py
+++ b/toolbox/commands/copy_screens.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional
 
-from toolbox.api.datagalaxy_api import get_access_token, Token
 from toolbox.api.datagalaxy_api_screens import DataGalaxyApiScreen
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 
@@ -18,12 +17,6 @@ def copy_screens(url_source: str,
     if url_target is None:
         url_target = url_source
 
-    integration_token_source = Token(token_source)
-    integration_token_target = Token(token_target)
-
-    source_access_token = get_access_token(url_source, integration_token_source)
-    target_access_token = get_access_token(url_target, integration_token_target)
-
     if workspace_source_name is None:
         logging.info("copy_screens - No source workspace name given : copying the clientspace's screens")
         source_workspace = None
@@ -31,7 +24,7 @@ def copy_screens(url_source: str,
         logging.info("copy_screens - Source workspace name given : copying the workspace's screens")
         workspaces_api_on_source_env = DataGalaxyApiWorkspace(
             url=url_source,
-            access_token=source_access_token
+            token=token_source
         )
         source_workspace = workspaces_api_on_source_env.get_workspace(workspace_source_name)
         if source_workspace is None:
@@ -44,14 +37,14 @@ def copy_screens(url_source: str,
         logging.info("copy_screens - Target workspace name given : writing on workspace's screens")
         workspaces_api_on_target_env = DataGalaxyApiWorkspace(
             url=url_target,
-            access_token=target_access_token
+            token=token_target
         )
         target_workspace = workspaces_api_on_target_env.get_workspace(workspace_target_name)
         if target_workspace is None:
             raise Exception(f'workspace {workspace_target_name} does not exist')
 
-    source_screens_api = DataGalaxyApiScreen(url=url_source, access_token=source_access_token, workspace=source_workspace)
-    target_screens_api = DataGalaxyApiScreen(url=url_target, access_token=target_access_token, workspace=target_workspace)
+    source_screens_api = DataGalaxyApiScreen(url=url_source, token=token_source, workspace=source_workspace)
+    target_screens_api = DataGalaxyApiScreen(url=url_target, token=token_target, workspace=target_workspace)
 
     source_screens = source_screens_api.list_screens()
     target_screens = target_screens_api.list_screens()
@@ -171,12 +164,12 @@ def copy_screens_parse(subparsers):
     copy_screens_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration source token',
+        help='source token',
         required=True)
     copy_screens_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration target token',
+        help='target token',
         required=False)
     copy_screens_parse.add_argument(
         '--workspace-source',

--- a/toolbox/commands/copy_technologies.py
+++ b/toolbox/commands/copy_technologies.py
@@ -1,23 +1,15 @@
 import logging
 
-from toolbox.api.datagalaxy_api import get_access_token, Token
 from toolbox.api.datagalaxy_api_technologies import DataGalaxyApiTechnology
 
 
 def copy_technologies(url_source: str,
                       url_target: str,
-                      integration_token_source_value: str,
-                      integration_token_target_value: str) -> int:
-    integration_token_source = Token(integration_token_source_value)
-    integration_token_target = Token(integration_token_target_value)
+                      token_source: str,
+                      token_target: str) -> int:
 
-    source_client_space_id = integration_token_source.get_client_space_id()
-
-    access_token_source = get_access_token(url_source, integration_token_source)
-    access_token_target = get_access_token(url_target, integration_token_target)
-
-    technologies_api_source = DataGalaxyApiTechnology(url=url_source, access_token=access_token_source)
-    technologies_api_target = DataGalaxyApiTechnology(url=url_target, access_token=access_token_target)
+    technologies_api_source = DataGalaxyApiTechnology(url=url_source, token=token_source)
+    technologies_api_target = DataGalaxyApiTechnology(url=url_target, token=token_target)
 
     source_technologies = technologies_api_source.list_technologies()
     target_technologies = technologies_api_target.list_technologies()
@@ -29,10 +21,10 @@ def copy_technologies(url_source: str,
     source_custom_technologies = list(filter(lambda technology: technology['creationUserId'] != "00000000-0000-0000-0000-000000000000", source_technologies))
 
     if len(source_custom_technologies) == 0:
-        logging.info(f'copy_technologies - No custom technology found on source client_space: {source_client_space_id}, aborting.')
+        logging.info('copy_technologies - No custom technology found on source client_space, aborting.')
         return 0
 
-    logging.info(f'copy_technologies - {len(source_custom_technologies)} custom technologies found on client_space: {source_client_space_id}')
+    logging.info(f'copy_technologies - {len(source_custom_technologies)} custom technologies found on source client_space')
 
     target_technology_codes = list(map(lambda t: t['technologyCode'], target_technologies))
 
@@ -48,7 +40,7 @@ def copy_technologies(url_source: str,
         technologies_api_target.insert_technology(source_custom)
         count_created_technologies += 1
 
-    logging.info(f'copy_technologies - {count_created_technologies} technologies were created on target client_space: {source_client_space_id}')
+    logging.info(f'copy_technologies - {count_created_technologies} technologies were created on target client_space')
     return count_created_technologies
 
 
@@ -68,10 +60,10 @@ def copy_technologies_parse(subparsers):
     copy_technologies_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration source token',
+        help='source token',
         required=True)
     copy_technologies_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration target token',
+        help='target token',
         required=True)

--- a/toolbox/commands/copy_usages.py
+++ b/toolbox/commands/copy_usages.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 
@@ -18,26 +18,22 @@ def copy_usages(url_source: str,
     if url_target is None:
         url_target = url_source
 
-    integration_token_source = Token(token_source)
-    integration_token_target = Token(token_target)
-    source_access_token = get_access_token(url_source, integration_token_source)
-    target_access_token = get_access_token(url_target, integration_token_target)
     workspaces_api_on_source_env = DataGalaxyApiWorkspace(
         url=url_source,
-        access_token=source_access_token)
+        token=token_source)
 
     workspaces_api_on_target_env = DataGalaxyApiWorkspace(
         url=url_target,
-        access_token=target_access_token
+        token=token_target
     )
     usages_on_source_workspace = DataGalaxyApiUsages(
         url=url_source,
-        access_token=source_access_token,
+        token=token_source,
         workspace=workspaces_api_on_source_env.get_workspace(workspace_source_name)
     )
     usages_on_target_workspace = DataGalaxyApiUsages(
         url=url_target,
-        access_token=target_access_token,
+        token=token_target,
         workspace=workspaces_api_on_target_env.get_workspace(workspace_target_name)
     )
 
@@ -66,7 +62,7 @@ def copy_usages_parse(subparsers):
     copy_usages_parse.add_argument(
         '--token-source',
         type=str,
-        help='integration token source environnement',
+        help='token source environnement',
         required=True)
     copy_usages_parse.add_argument(
         '--url-target',
@@ -75,7 +71,7 @@ def copy_usages_parse(subparsers):
     copy_usages_parse.add_argument(
         '--token-target',
         type=str,
-        help='integration token target environnement (if undefined, use token source)')
+        help='token target environnement (if undefined, use token source)')
     copy_usages_parse.add_argument(
         '--workspace-source',
         type=str,

--- a/toolbox/commands/delete_attributes.py
+++ b/toolbox/commands/delete_attributes.py
@@ -1,21 +1,16 @@
 import logging
 
-from toolbox.api.datagalaxy_api import get_access_token, Token
 from toolbox.api.datagalaxy_api_attributes import DataGalaxyApiAttributes, custom_attributes
 
 
-def delete_attributes(url: str, integration_token_value: str) -> bool:
-    integration_token = Token(integration_token_value)
-    client_space_id = integration_token.get_client_space_id()
-
-    access_token_target = get_access_token(url, integration_token)
-    attributes_api_target = DataGalaxyApiAttributes(url=url, access_token=access_token_target)
+def delete_attributes(url: str, token: str) -> bool:
+    attributes_api_target = DataGalaxyApiAttributes(url=url, token=token)
     custom_target_attributes = custom_attributes(attributes_api_target)
     logging.info(
-        f'delete_attributes - {len(custom_target_attributes)} custom attributes found on client_space: {client_space_id}')
+        f'delete_attributes - {len(custom_target_attributes)} custom attributes found on client_space')
     attributes_api_target.delete_all_attributes(custom_target_attributes)
     logging.info(
-        f'delete_attributes - {len(custom_target_attributes)} custom attributes deleted on client_space: {client_space_id}')
+        f'delete_attributes - {len(custom_target_attributes)} custom attributes deleted on client_space')
     return True
 
 

--- a/toolbox/commands/delete_dataprocessings.py
+++ b/toolbox/commands/delete_dataprocessings.py
@@ -1,4 +1,4 @@
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_dataprocessings import DataGalaxyApiDataprocessings
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 import logging
@@ -8,11 +8,9 @@ def delete_dataprocessings(url: str,
                            token: str,
                            workspace_name: str) -> DataGalaxyBulkResult:
 
-    integration_token = Token(token)
-    access_token = get_access_token(url, integration_token)
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
-        access_token=access_token)
+        token=token)
 
     workspace = workspaces_api.get_workspace(workspace_name)
 
@@ -22,7 +20,7 @@ def delete_dataprocessings(url: str,
     # on récupère les propriétés du dataprocessings du workspace_source
     dataprocessings_api = DataGalaxyApiDataprocessings(
         url=url,
-        access_token=access_token,
+        token=token,
         workspace=workspace
     )
     dataprocessings = dataprocessings_api.list_dataprocessings(
@@ -51,7 +49,7 @@ def delete_dataprocessings_parse(subparsers):
     delete_dataprocessings_parse.add_argument(
         '--token',
         type=str,
-        help='integration token',
+        help='token',
         required=True)
     delete_dataprocessings_parse.add_argument(
         '--workspace',

--- a/toolbox/commands/delete_dictionary.py
+++ b/toolbox/commands/delete_dictionary.py
@@ -1,4 +1,4 @@
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 import logging
@@ -8,11 +8,9 @@ def delete_dictionary(url: str,
                       token: str,
                       workspace_name: str) -> DataGalaxyBulkResult:
 
-    integration_token = Token(token)
-    access_token = get_access_token(url, integration_token)
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
-        access_token=access_token)
+        token=token)
 
     workspace = workspaces_api.get_workspace(workspace_name)
 
@@ -22,7 +20,7 @@ def delete_dictionary(url: str,
     # on récupère les propriétés du dictionary du workspace_source
     dictionary_api = DataGalaxyApiDictionary(
         url=url,
-        access_token=access_token,
+        token=token,
         workspace=workspace
     )
     sources = dictionary_api.list_sources(workspace_name)
@@ -50,7 +48,7 @@ def delete_dictionary_parse(subparsers):
     delete_dictionary_parse.add_argument(
         '--token',
         type=str,
-        help='integration token',
+        help='token',
         required=True)
     delete_dictionary_parse.add_argument(
         '--workspace',

--- a/toolbox/commands/delete_glossary.py
+++ b/toolbox/commands/delete_glossary.py
@@ -1,4 +1,4 @@
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_glossary import DataGalaxyApiGlossary
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 import logging
@@ -8,11 +8,9 @@ def delete_glossary(url: str,
                     token: str,
                     workspace_name: str) -> DataGalaxyBulkResult:
 
-    integration_token = Token(token)
-    access_token = get_access_token(url, integration_token)
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
-        access_token=access_token)
+        token=token)
 
     workspace = workspaces_api.get_workspace(workspace_name)
 
@@ -22,7 +20,7 @@ def delete_glossary(url: str,
     # on récupère les propriétés du glossary du workspace_source
     glossary_api = DataGalaxyApiGlossary(
         url=url,
-        access_token=access_token,
+        token=token,
         workspace=workspace
     )
     glossary_properties = glossary_api.list_properties(
@@ -51,7 +49,7 @@ def delete_glossary_parse(subparsers):
     delete_glossary_parse.add_argument(
         '--token',
         type=str,
-        help='integration token',
+        help='token',
         required=True)
     delete_glossary_parse.add_argument(
         '--workspace',

--- a/toolbox/commands/delete_usages.py
+++ b/toolbox/commands/delete_usages.py
@@ -1,4 +1,4 @@
-from toolbox.api.datagalaxy_api import get_access_token, Token, DataGalaxyBulkResult
+from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
 from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 import logging
@@ -8,11 +8,9 @@ def delete_usages(url: str,
                   token: str,
                   workspace_name: str) -> DataGalaxyBulkResult:
 
-    integration_token = Token(token)
-    access_token = get_access_token(url, integration_token)
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
-        access_token=access_token)
+        token=token)
 
     workspace = workspaces_api.get_workspace(workspace_name)
 
@@ -22,7 +20,7 @@ def delete_usages(url: str,
     # on récupère les propriétés du usages du workspace_source
     usages_api = DataGalaxyApiUsages(
         url=url,
-        access_token=access_token,
+        token=token,
         workspace=workspace
     )
     usages = usages_api.list_usages(workspace_name)
@@ -50,7 +48,7 @@ def delete_usages_parse(subparsers):
     delete_usages_parse.add_argument(
         '--token',
         type=str,
-        help='integration token',
+        help='token',
         required=True)
     delete_usages_parse.add_argument(
         '--workspace',


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](../blob/main/CONTRIBUTING.md) ;
- [x] I have read the [Contributor License Agreement (CLA)](../blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md) and understand that the submission of this PR will constitute an  electronic signature of my agreement of the terms and conditions of DataGalaxy's CLA ;
- [x] There is an approved issue describing the change when contributing a new feature ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:

In the past, the API had a different handling of tokens. Now, the old "authenticate" route is deprecated, so a big chunk of code could be removed. 

#### Changes proposed in this pull request:
<!--Fill These Bullet Points-->
- Removed old authenticate methods
- Removed "access token" or "integration token" names, everything is now a "token" without detail
- Changed the tests accordingly 
