### PR TITLE
Enhance bulktree creation and clean up glossary, uses and dataprocessings

### DIFF
--- a/tests/test_copy_usages.py
+++ b/tests/test_copy_usages.py
@@ -1,4 +1,4 @@
-from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.commands.copy_usages import copy_usages
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
@@ -7,32 +7,32 @@ import pytest as pytest
 
 # Mocks
 
-def mock_list_usages_on_source_workspace(self, workspace_name):
+def mock_list_objects_on_source_workspace(self, workspace_name):
     if workspace_name == 'workspace_source':
-        return ['usage1', 'usage2', 'usage3']
+        return [['object1', 'object2', 'object3']]
     return []
 
 
 # Scenarios
 
-def test_copy_usages_when_no_usage_on_target(mocker):
+def test_copy_objects_when_no_object_on_target(mocker):
     # GIVEN
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source', 'workspace_target']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
-    workspace_source_mock.return_value = 'workspace_source'
-    usages_on_source_workspace_mock = mocker.patch.object(
-        DataGalaxyApiUsages,
-        'list_usages',
+    workspace_source_mock.return_value = {'name': 'workspace', 'isVersioningEnabled': False}
+    objects_on_source_workspace_mock = mocker.patch.object(
+        DataGalaxyApiModules,
+        'list_objects',
         autospec=True
     )
-    usages_on_source_workspace_mock.side_effect = mock_list_usages_on_source_workspace
-    bulk_upsert_usages_on_target_workspace_mock = mocker.patch.object(
-        DataGalaxyApiUsages,
-        'bulk_upsert_usages_tree',
+    objects_on_source_workspace_mock.side_effect = mock_list_objects_on_source_workspace
+    bulk_upsert_objects_on_target_workspace_mock = mocker.patch.object(
+        DataGalaxyApiModules,
+        'bulk_upsert_tree',
         autospec=True
     )
-    bulk_upsert_usages_on_target_workspace_mock.return_value = DataGalaxyBulkResult(
+    bulk_upsert_objects_on_target_workspace_mock.return_value = DataGalaxyBulkResult(
         total=3,
         created=3,
         updated=0,
@@ -54,8 +54,8 @@ def test_copy_usages_when_no_usage_on_target(mocker):
     # ASSERT / VERIFY
 
     assert result == DataGalaxyBulkResult(total=3, created=3, updated=0, unchanged=0, deleted=0)
-    assert usages_on_source_workspace_mock.call_count == 1
-    assert bulk_upsert_usages_on_target_workspace_mock.call_count == 1
+    assert objects_on_source_workspace_mock.call_count == 1
+    assert bulk_upsert_objects_on_target_workspace_mock.call_count == 1
 
 
 def test_copy_usages_when_workspace_target_does_not_exist(mocker):
@@ -64,15 +64,15 @@ def test_copy_usages_when_workspace_target_does_not_exist(mocker):
     workspaces.return_value = ['workspace_source']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
     workspace_source_mock.return_value = None
-    usages_on_source_workspace_mock = mocker.patch.object(
-        DataGalaxyApiUsages,
-        'list_usages',
+    objects_on_source_workspace_mock = mocker.patch.object(
+        DataGalaxyApiModules,
+        'list_objects',
         autospec=True
     )
-    usages_on_source_workspace_mock.side_effect = mock_list_usages_on_source_workspace
+    objects_on_source_workspace_mock.side_effect = mock_list_objects_on_source_workspace
 
     # ASSERT / VERIFY
-    with pytest.raises(Exception, match='workspace workspace_target does not exist'):
+    with pytest.raises(Exception, match='workspace workspace_source does not exist'):
         copy_usages(
             url_source='url_source',
             token_source='token_source',

--- a/tests/test_delete_dataprocessings.py
+++ b/tests/test_delete_dataprocessings.py
@@ -1,20 +1,17 @@
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api_dataprocessings import DataGalaxyApiDataprocessings
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.commands.delete_dataprocessings import delete_dataprocessings
 
 
 # Mock
-def mock_list_dataprocessings(self, data_type):
-    if self.url == 'url':
-        return [
-            {
-                'id': '1',
-                'name': 'Object',
-                'description': 'An object in the dataprocessings'
-            }
-        ]
-
-    return []
+mock_list_objects = [[
+                        {
+                            'id': '1',
+                            'name': 'Object',
+                            'path': "\\\\Object",
+                            'description': 'Just a simple object'
+                        }
+                    ]]
 
 
 # Scenarios
@@ -23,14 +20,14 @@ def test_delete_dataprocessings(mocker):
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
-    workspace_mock.return_value = {'isVersioningEnabled': False}
-    dataprocessings_list_mock = mocker.patch.object(DataGalaxyApiDataprocessings, 'list_dataprocessings', autospec=True)
-    dataprocessings_list_mock.side_effect = mock_list_dataprocessings
-    delete_dataprocessings_mock = mocker.patch.object(DataGalaxyApiDataprocessings, 'delete_objects', autospec=True)
-    delete_dataprocessings_mock.return_value = True
+    workspace_mock.return_value = {'name': 'workspace', 'isVersioningEnabled': False}
+    objects_list_mock = mocker.patch.object(DataGalaxyApiModules, 'list_objects', autospec=True)
+    objects_list_mock.return_value = mock_list_objects
+    delete_objects_mock = mocker.patch.object(DataGalaxyApiModules, 'delete_objects', autospec=True)
+    delete_objects_mock.return_value = True
 
     # THEN
     result = delete_dataprocessings(url='url', token='token', workspace_name="workspace")
 
     # ASSERT / VERIFY
-    assert result is True
+    assert result == 0

--- a/tests/test_delete_glossary.py
+++ b/tests/test_delete_glossary.py
@@ -1,20 +1,17 @@
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api_glossary import DataGalaxyApiGlossary
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.commands.delete_glossary import delete_glossary
 
 
 # Mock
-def mock_list_glossary_properties(self, data_type):
-    if self.url == 'url':
-        return [
-            {
-                'id': '1',
-                'name': 'Object',
-                'description': 'An object in the glossary'
-            }
-        ]
-
-    return []
+mock_list_objects = [[
+                        {
+                            'id': '1',
+                            'name': 'Object',
+                            'path': "\\\\Object",
+                            'description': 'Just a simple object'
+                        }
+                    ]]
 
 
 # Scenarios
@@ -23,14 +20,14 @@ def test_delete_glossary(mocker):
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
-    workspace_mock.return_value = 'workspace'
-    glossary_list_mock = mocker.patch.object(DataGalaxyApiGlossary, 'list_properties', autospec=True)
-    glossary_list_mock.side_effect = mock_list_glossary_properties
-    delete_glossary_mock = mocker.patch.object(DataGalaxyApiGlossary, 'delete_objects', autospec=True)
-    delete_glossary_mock.return_value = True
+    workspace_mock.return_value = {'name': 'workspace', 'isVersioningEnabled': False}
+    objects_list_mock = mocker.patch.object(DataGalaxyApiModules, 'list_objects', autospec=True)
+    objects_list_mock.return_value = mock_list_objects
+    delete_objects_mock = mocker.patch.object(DataGalaxyApiModules, 'delete_objects', autospec=True)
+    delete_objects_mock.return_value = True
 
     # THEN
     result = delete_glossary(url='url', token='token', workspace_name="workspace")
 
     # ASSERT / VERIFY
-    assert result is True
+    assert result == 0

--- a/tests/test_delete_usages.py
+++ b/tests/test_delete_usages.py
@@ -1,20 +1,17 @@
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.commands.delete_usages import delete_usages
 
 
 # Mock
-def mock_list_usages(self, data_type):
-    if self.url == 'url':
-        return [
-            {
-                'id': '1',
-                'name': 'Object',
-                'description': 'An object in the usages'
-            }
-        ]
-
-    return []
+mock_list_objects = [[
+                        {
+                            'id': '1',
+                            'name': 'Object',
+                            'path': "\\\\Object",
+                            'description': 'Just a simple object'
+                        }
+                    ]]
 
 
 # Scenarios
@@ -23,14 +20,14 @@ def test_delete_usages(mocker):
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
-    workspace_mock.return_value = 'workspace'
-    usages_list_mock = mocker.patch.object(DataGalaxyApiUsages, 'list_usages', autospec=True)
-    usages_list_mock.side_effect = mock_list_usages
-    delete_usages_mock = mocker.patch.object(DataGalaxyApiUsages, 'delete_objects', autospec=True)
-    delete_usages_mock.return_value = True
+    workspace_mock.return_value = {'name': 'workspace', 'isVersioningEnabled': False}
+    objects_list_mock = mocker.patch.object(DataGalaxyApiModules, 'list_objects', autospec=True)
+    objects_list_mock.return_value = mock_list_objects
+    delete_objects_mock = mocker.patch.object(DataGalaxyApiModules, 'delete_objects', autospec=True)
+    delete_objects_mock.return_value = True
 
     # THEN
     result = delete_usages(url='url', token='token', workspace_name="workspace")
 
     # ASSERT / VERIFY
-    assert result is True
+    assert result == 0

--- a/toolbox/api/datagalaxy_api.py
+++ b/toolbox/api/datagalaxy_api.py
@@ -69,7 +69,7 @@ def remove_technology_code(node):
 def build_bulktree(objects):
     root = []  # Root level for all unique trees
 
-    def find_or_create_child(children, path_segment, type_segment, functional_path_segment, attributes):
+    def find_or_create_child(children, path_segment, type_segment, functional_path_segment, attributes, dpis):
         # Look for a child with the same path and type
         for child in children:
             if child['technicalName'] == path_segment and child['type'] == type_segment:
@@ -86,6 +86,9 @@ def build_bulktree(objects):
             **attributes,  # Flatten all attribute key-values into this node
             'children': []
         }
+        # specific for dataProcessingItems
+        if dpis is not None:
+            new_child['dataProcessingItems'] = dpis
         children.append(new_child)
         return new_child
 
@@ -94,6 +97,7 @@ def build_bulktree(objects):
         type_segments = obj['typePath'][1:].split(PATH_SEPARATOR)
         functional_path_segments = obj['functionalPath'][1:].split(PATH_SEPARATOR)
         attributes = obj.get('attributes')
+        dpis = obj.get('dataProcessingItems')
         handle_timeserie(obj)
 
         current_level = root  # Start from the root level
@@ -101,7 +105,9 @@ def build_bulktree(objects):
         for i, (path_segment, type_segment, functional_path_segment) in enumerate(zip(path_segments, type_segments, functional_path_segments)):
             # Pass attributes only at the right level (the last)
             attributes_to_send = attributes if i == (len(path_segments) - 1) else {}
-            next_node = find_or_create_child(current_level, path_segment, type_segment, functional_path_segment, attributes_to_send)
+            # Pass dpis (if exists) only at the right level (the last)
+            dpis_to_send = dpis if i == (len(path_segments) - 1) else None
+            next_node = find_or_create_child(current_level, path_segment, type_segment, functional_path_segment, attributes_to_send, dpis_to_send)
             current_level = next_node['children']  # Move to the next level of children
 
     return root

--- a/toolbox/api/datagalaxy_api_modules.py
+++ b/toolbox/api/datagalaxy_api_modules.py
@@ -1,0 +1,121 @@
+import logging
+import requests as requests
+from toolbox.api.datagalaxy_api import build_bulktree, prune_tree, remove_technology_code
+from typing import Optional
+
+
+class DataGalaxyApiModules:
+    def __init__(self, url: str, token: str, workspace: dict, module: str):
+        if module not in ["Glossary", "DataProcessing", "Uses"]:
+            raise Exception('The specified module does not exist.')
+        self.module = module
+        if module == "Glossary":
+            self.route = "properties"
+        if module == "DataProcessing":
+            self.route = "dataProcessing"
+        if module == "Uses":
+            self.route = "usages"
+
+        if workspace["isVersioningEnabled"]:
+            raise Exception('Workspaces with versioning enabled are currently not supported.')
+        self.url = url
+        self.token = token
+        self.workspace = workspace
+
+    def list_objects(self, workspace_name: str, include_links=False) -> list:
+        version_id = self.workspace['defaultVersionId']
+        if include_links is True:
+            params = {'versionId': version_id, 'limit': '5000', 'includeLinks': 'true'}
+        else:
+            params = {'versionId': version_id, 'limit': '5000', 'includeAttributes': 'true'}
+        headers = {'Authorization': f"Bearer {self.token}"}
+        response = requests.get(f"{self.url}/{self.route}", params=params, headers=headers)
+        code = response.status_code
+        body_json = response.json()
+        if code != 200:
+            raise Exception(body_json['error'])
+        logging.info(
+            f'list_objects - {len(body_json["results"])} objects found on '
+            f'workspace "{workspace_name}" in module {self.module}')
+        result_pages = [body_json['results']]
+        next_page = body_json["next_page"]
+        while next_page is not None:
+            logging.info('Fetching another page from the API...')
+            headers = {'Authorization': f"Bearer {self.token}"}
+            response = requests.get(next_page, headers=headers)
+            body_json = response.json()
+            logging.info(
+                f'list_objects - {len(body_json["results"])} objects found on '
+                f'workspace "{workspace_name}" in module {self.module}')
+            next_page = body_json["next_page"]
+            result_pages.append(body_json['results'])
+        return result_pages
+
+    # This is a specific request for dataProcessing items
+    def list_object_items(self, workspace_name: str, parent_id: str) -> list:
+        if self.module != "DataProcessing":
+            raise Exception(f'This method is not available for the module {self.module}')
+
+        version_id = self.workspace['defaultVersionId']
+        params = {'versionId': version_id, 'parentId': parent_id, 'includeAttributes': 'true'}
+        headers = {'Authorization': f"Bearer {self.token}"}
+        response = requests.get(f"{self.url}/dataProcessingItem", params=params, headers=headers)
+        code = response.status_code
+        body_json = response.json()
+        if code != 200:
+            raise Exception(body_json['error'])
+        result = []
+        result = result + body_json['results']
+        next_page = body_json["next_page"]
+        while next_page is not None:
+            headers = {'Authorization': f"Bearer {self.token}"}
+            response = requests.get(next_page, headers=headers)
+            body_json = response.json()
+            next_page = body_json["next_page"]
+            result = result + body_json['results']
+        return result
+
+    def bulk_upsert_tree(self, workspace_name: str, objects: list, tag_value: Optional[str]) -> int:
+        # Objects can be in pages, so one POST request per page
+        for page in objects:
+            # Existing entities are updated and non-existing ones are created.
+            bulktree = build_bulktree(page)
+
+            if tag_value is not None:
+                bulktree = prune_tree(bulktree, tag_value)
+
+            # If a parent usage has a technology, it is necessary to delete the "technologyCode" property in every children
+            # Otherwise the API returns an error. Only the parent can hold the "technologyCode" property
+            for tree in bulktree:
+                if 'children' in tree:
+                    for children in tree['children']:
+                        remove_technology_code(children)
+
+            version_id = self.workspace['defaultVersionId']
+            headers = {'Authorization': f"Bearer {self.token}"}
+            response = requests.post(f"{self.url}/{self.route}/bulktree/{version_id}", json=bulktree, headers=headers)
+            code = response.status_code
+            body_json = response.json()
+            if 200 <= code < 300:
+                logging.info(f'bulk_upsert_tree - {body_json}')
+            if 400 <= code < 500:
+                raise Exception(body_json['error'])
+
+        return 200
+
+    def delete_objects(self, workspace_name: str, ids: list) -> int:
+        if len(ids) < 1:
+            logging.warn(f'Nothing to delete on workspace "{workspace_name}" in module {self.module}, aborting.')
+            return 0
+        version_id = self.workspace['defaultVersionId']
+        headers = {'Authorization': f"Bearer {self.token}"}
+        response = requests.delete(f"{self.url}/{self.route}/bulk/{version_id}",
+                                   json=ids,
+                                   headers=headers)
+        code = response.status_code
+        body_json = response.json()
+        if code != 200:
+            raise Exception(body_json['error'])
+        logging.info(
+            f'delete_objects - {body_json["totalDeleted"]} objects were deleted on workspace "{workspace_name}" in module {self.module}')
+        return 0

--- a/toolbox/commands/copy_usages.py
+++ b/toolbox/commands/copy_usages.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
-from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 
 
@@ -21,34 +21,40 @@ def copy_usages(url_source: str,
     workspaces_api_on_source_env = DataGalaxyApiWorkspace(
         url=url_source,
         token=token_source)
+    source_workspace = workspaces_api_on_source_env.get_workspace(workspace_source_name)
+    if source_workspace is None:
+        raise Exception(f'workspace {workspace_source_name} does not exist')
 
     workspaces_api_on_target_env = DataGalaxyApiWorkspace(
         url=url_target,
         token=token_target
     )
-    usages_on_source_workspace = DataGalaxyApiUsages(
+    target_workspace = workspaces_api_on_target_env.get_workspace(workspace_target_name)
+    if target_workspace is None:
+        raise Exception(f'workspace {workspace_target_name} does not exist')
+
+    source_module_api = DataGalaxyApiModules(
         url=url_source,
         token=token_source,
-        workspace=workspaces_api_on_source_env.get_workspace(workspace_source_name)
+        workspace=workspaces_api_on_source_env.get_workspace(workspace_source_name),
+        module="Uses"
     )
-    usages_on_target_workspace = DataGalaxyApiUsages(
+    target_module_api = DataGalaxyApiModules(
         url=url_target,
         token=token_target,
-        workspace=workspaces_api_on_target_env.get_workspace(workspace_target_name)
+        workspace=workspaces_api_on_target_env.get_workspace(workspace_target_name),
+        module="Uses"
     )
 
-    if workspaces_api_on_target_env.get_workspace(workspace_target_name):
-        # on récupère les usages du workspace_source
-        workspace_source_usages = usages_on_source_workspace.list_usages(workspace_source_name)
+    # fetch objects from source workspace
+    source_objects = source_module_api.list_objects(workspace_source_name)
 
-        # on copie ces usages sur le workspace_target
-        return usages_on_target_workspace.bulk_upsert_usages_tree(
-            workspace_name=workspace_target_name,
-            usages=workspace_source_usages,
-            tag_value=tag_value
-        )
-
-    raise Exception(f'workspace {workspace_target_name} does not exist')
+    # create objects on target workspace
+    return target_module_api.bulk_upsert_tree(
+        workspace_name=workspace_target_name,
+        objects=source_objects,
+        tag_value=tag_value
+    )
 
 
 def copy_usages_parse(subparsers):

--- a/toolbox/commands/delete_dataprocessings.py
+++ b/toolbox/commands/delete_dataprocessings.py
@@ -1,12 +1,11 @@
-from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
-from toolbox.api.datagalaxy_api_dataprocessings import DataGalaxyApiDataprocessings
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-import logging
+from toolbox.api.datagalaxy_api import find_root_objects
 
 
 def delete_dataprocessings(url: str,
                            token: str,
-                           workspace_name: str) -> DataGalaxyBulkResult:
+                           workspace_name: str) -> str:
 
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
@@ -17,25 +16,25 @@ def delete_dataprocessings(url: str,
     if not workspace:
         raise Exception(f'workspace {workspace_name} does not exist')
 
-    # on récupère les propriétés du dataprocessings du workspace_source
-    dataprocessings_api = DataGalaxyApiDataprocessings(
+    # fetching objects from source workspace
+    module_api = DataGalaxyApiModules(
         url=url,
         token=token,
-        workspace=workspace
+        workspace=workspace,
+        module="DataProcessing"
     )
-    dataprocessings = dataprocessings_api.list_dataprocessings(
+    objects = module_api.list_objects(
         workspace_name)
 
-    ids = list(map(lambda object: object['id'], dataprocessings))
+    for page in objects:
+        root_objects = find_root_objects(page)
+        ids = list(map(lambda object: object['id'], root_objects))
+        module_api.delete_objects(
+            workspace_name=workspace_name,
+            ids=ids
+        )
 
-    if ids is None or len(ids) < 1:
-        logging.warn("Nothing to delete in this module")
-        return 0
-
-    return dataprocessings_api.delete_objects(
-        workspace_name=workspace_name,
-        ids=ids
-    )
+    return 0
 
 
 def delete_dataprocessings_parse(subparsers):

--- a/toolbox/commands/delete_usages.py
+++ b/toolbox/commands/delete_usages.py
@@ -1,12 +1,11 @@
-from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
-from toolbox.api.datagalaxy_api_usages import DataGalaxyApiUsages
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-import logging
+from toolbox.api.datagalaxy_api import find_root_objects
 
 
 def delete_usages(url: str,
                   token: str,
-                  workspace_name: str) -> DataGalaxyBulkResult:
+                  workspace_name: str) -> str:
 
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
@@ -17,24 +16,25 @@ def delete_usages(url: str,
     if not workspace:
         raise Exception(f'workspace {workspace_name} does not exist')
 
-    # on récupère les propriétés du usages du workspace_source
-    usages_api = DataGalaxyApiUsages(
+    # fetching objects from source workspace
+    module_api = DataGalaxyApiModules(
         url=url,
         token=token,
-        workspace=workspace
+        workspace=workspace,
+        module="Uses"
     )
-    usages = usages_api.list_usages(workspace_name)
+    objects = module_api.list_objects(
+        workspace_name)
 
-    ids = list(map(lambda object: object['id'], usages))
+    for page in objects:
+        root_objects = find_root_objects(page)
+        ids = list(map(lambda object: object['id'], root_objects))
+        module_api.delete_objects(
+            workspace_name=workspace_name,
+            ids=ids
+        )
 
-    if ids is None or len(ids) < 1:
-        logging.warn("Nothing to delete in this module")
-        return 0
-
-    return usages_api.delete_objects(
-        workspace_name=workspace_name,
-        ids=ids
-    )
+    return 0
 
 
 def delete_usages_parse(subparsers):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](../blob/main/CONTRIBUTING.md) ;
- [x] I have read the [Contributor License Agreement (CLA)](../blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md) and understand that the submission of this PR will constitute an  electronic signature of my agreement of the terms and conditions of DataGalaxy's CLA ;
- [x] There is an approved issue describing the change when contributing a new feature ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:

The copy-glossary and copy-usages were relying on old code that needed some cleaning. Moreover, the bulktree method had a big flaw: when trying to copy too many objects, the method would fail. 
This PR introduces a new bulktree method that takes advantage of the API pagination capacity. This tool should not be limited by volume anymore. 
Finally, all three modules (Uses, Glossary, DataProcessing) now rely on the same codebase and API methods. This rationalization will make maintenance easier. 
This work will allow another PR in the future to clean the Dictionary methods too, as it is the module with the highest volumetry in general.

#### Changes proposed in this pull request:
<!--Fill These Bullet Points-->
- Implement a new bulktree method that uses API pagination
- Uses, Glossary and DataProcessing modules now share the same common code
- Clean some old code
