### PR TITLE
Enhance dictionary API with pagination

### DIFF
--- a/tests/test_copy_dictionary.py
+++ b/tests/test_copy_dictionary.py
@@ -1,4 +1,4 @@
-from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.commands.copy_dictionary import copy_dictionary
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
 import pytest as pytest
@@ -6,26 +6,26 @@ import pytest as pytest
 
 # Mocks
 
-def mock_list_sources_on_source_workspace(self, workspace_name):
+def mock_list_objects_on_source_workspace(self, workspace_name):
     if workspace_name == 'workspace_source':
-        return ['source1', 'source2', 'source3']
+        return [['object1', 'object2', 'object3']]
     return []
 
 
 # Scenarios
 
-def test_copy_sources_when_workspace_source_does_not_exist(mocker):
+def test_copy_dictionary_when_workspace_target_does_not_exist(mocker):
     # GIVEN
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace_source']
     workspace_source_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
     workspace_source_mock.return_value = None
-    sources_on_source_workspace_mock = mocker.patch.object(
-        DataGalaxyApiDictionary,
-        'list_sources',
+    objects_on_source_workspace_mock = mocker.patch.object(
+        DataGalaxyApiModules,
+        'list_objects',
         autospec=True
     )
-    sources_on_source_workspace_mock.side_effect = mock_list_sources_on_source_workspace
+    objects_on_source_workspace_mock.side_effect = mock_list_objects_on_source_workspace
 
     # ASSERT / VERIFY
     with pytest.raises(Exception, match='workspace workspace_source does not exist'):

--- a/tests/test_delete_dictionary.py
+++ b/tests/test_delete_dictionary.py
@@ -1,20 +1,17 @@
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.commands.delete_dictionary import delete_dictionary
 
 
 # Mock
-def mock_list_sources(self, data_type):
-    if self.url == 'url':
-        return [
-            {
-                'id': '1',
-                'name': 'Object',
-                'description': 'An object in the dictionary'
-            }
-        ]
-
-    return []
+mock_list_objects = [[
+                        {
+                            'id': '1',
+                            'name': 'Object',
+                            'path': "\\\\Object",
+                            'description': 'Just a simple object'
+                        }
+                    ]]
 
 
 # Scenarios
@@ -23,14 +20,14 @@ def test_delete_dictionary(mocker):
     workspaces = mocker.patch.object(DataGalaxyApiWorkspace, 'list_workspaces', autospec=True)
     workspaces.return_value = ['workspace']
     workspace_mock = mocker.patch.object(DataGalaxyApiWorkspace, 'get_workspace', autospec=True)
-    workspace_mock.return_value = {'isVersioningEnabled': False}
-    dictionary_list_mock = mocker.patch.object(DataGalaxyApiDictionary, 'list_sources', autospec=True)
-    dictionary_list_mock.side_effect = mock_list_sources
-    delete_dictionary_mock = mocker.patch.object(DataGalaxyApiDictionary, 'delete_sources', autospec=True)
-    delete_dictionary_mock.return_value = True
+    workspace_mock.return_value = {'name': 'workspace', 'isVersioningEnabled': False}
+    objects_list_mock = mocker.patch.object(DataGalaxyApiModules, 'list_objects', autospec=True)
+    objects_list_mock.return_value = mock_list_objects
+    delete_objects_mock = mocker.patch.object(DataGalaxyApiModules, 'delete_objects', autospec=True)
+    delete_objects_mock.return_value = True
 
     # THEN
     result = delete_dictionary(url='url', token='token', workspace_name="workspace")
 
     # ASSERT / VERIFY
-    assert result is True
+    assert result == 0

--- a/toolbox/api/datagalaxy_api.py
+++ b/toolbox/api/datagalaxy_api.py
@@ -122,6 +122,26 @@ def find_root_objects(objects: list) -> list:
     return root_objects
 
 
+def create_batches(input_arrays, max_size=5000):
+    batches = []  # This will hold the list of arrays
+    current_batch = []  # Temporary array to build chunks
+
+    for arr in input_arrays:
+        for obj in arr:  # Add each object from the input array
+            if len(current_batch) < max_size:
+                current_batch.append(obj)
+            else:
+                # When the current array reaches max size, save it and start a new one
+                batches.append(current_batch)
+                current_batch = [obj]
+
+    # Add the remaining objects in `current_batch` if it's not empty
+    if current_batch:
+        batches.append(current_batch)
+
+    return batches
+
+
 def to_bulk_tree(properties: list) -> list:
     if properties is None or len(properties) == 0:
         logging.warn("Cannot bulk upsert an empty list of objects")

--- a/toolbox/commands/delete_dictionary.py
+++ b/toolbox/commands/delete_dictionary.py
@@ -1,12 +1,11 @@
-from toolbox.api.datagalaxy_api import DataGalaxyBulkResult
-from toolbox.api.datagalaxy_api_dictionary import DataGalaxyApiDictionary
+from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
-import logging
+from toolbox.api.datagalaxy_api import find_root_objects
 
 
 def delete_dictionary(url: str,
                       token: str,
-                      workspace_name: str) -> DataGalaxyBulkResult:
+                      workspace_name: str) -> int:
 
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
@@ -17,24 +16,25 @@ def delete_dictionary(url: str,
     if not workspace:
         raise Exception(f'workspace {workspace_name} does not exist')
 
-    # on récupère les propriétés du dictionary du workspace_source
-    dictionary_api = DataGalaxyApiDictionary(
+    # fetching objects from source workspace
+    module_api = DataGalaxyApiModules(
         url=url,
         token=token,
-        workspace=workspace
+        workspace=workspace,
+        module="Dictionary"
     )
-    sources = dictionary_api.list_sources(workspace_name)
+    objects = module_api.list_objects(
+        workspace_name)
 
-    ids = list(map(lambda object: object['id'], sources))
+    for page in objects:
+        root_objects = find_root_objects(page)
+        ids = list(map(lambda object: object['id'], root_objects))
+        module_api.delete_objects(
+            workspace_name=workspace_name,
+            ids=ids
+        )
 
-    if ids is None or len(ids) < 1:
-        logging.warn("Nothing to delete in this module")
-        return 0
-
-    return dictionary_api.delete_sources(
-        workspace_name=workspace_name,
-        ids=ids
-    )
+    return 0
 
 
 def delete_dictionary_parse(subparsers):


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [x] I have read the [Contribution Guide](../blob/main/CONTRIBUTING.md) ;
- [x] I have read the [Contributor License Agreement (CLA)](../blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md) and understand that the submission of this PR will constitute an  electronic signature of my agreement of the terms and conditions of DataGalaxy's CLA ;
- [x] There is an approved issue describing the change when contributing a new feature ;
- [x] I have added tests that prove my fix is effective or that my feature works ;
- [x] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:

There it is! The dictionary part of the toolbox now uses the new API pagination method. As a result, it is now possible to copy large amount of objects. 

#### Changes proposed in this pull request:
<!--Fill These Bullet Points-->
- Enhance dictionary methods by using new API pagination
