### PR TITLE
Prototype `--no-verify-ssl` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If you want to use the DataGalaxy Toolbox on MacOS or Unix, you need to build a 
 
 ##### Parameters
 - [optional arguments] `-h`, `--help`- show help message  
+- `-v`, `--verbose` - increase output verbosity
+- `--no-verify-ssl` - disable SSL certificate verification for HTTPS requests (default: enabled)
 - `--url` - The API URL of your DataGalaxy environment
 - `--token` - A DataGalaxy Token, either an Integration Token or a Personal Access Token
 - `--url-source`- The API URL of the source environnement

--- a/toolbox/__main__.py
+++ b/toolbox/__main__.py
@@ -1,7 +1,10 @@
 import argparse
 import logging
+import requests
 import sys
 
+from urllib3.exceptions import InsecureRequestWarning
+from toolbox.api.http_client import HttpClient
 from toolbox.commands.copy_attributes import copy_attributes_parse, copy_attributes
 from toolbox.commands.copy_technologies import copy_technologies_parse, copy_technologies
 from toolbox.commands.copy_screens import copy_screens_parse, copy_screens
@@ -21,6 +24,8 @@ def run(args):
     # create the top-level parser
     parser = argparse.ArgumentParser(description='Toolbox')
     parser.add_argument("-v", "--verbose", help="increase output verbosity",
+                        action="store_true")
+    parser.add_argument("--no-verify-ssl", help="disable SSL certificate verification for HTTPS requests",
                         action="store_true")
     subparsers = parser.add_subparsers(help='sub-command help', dest='subparsers_name')
     # Clientspace
@@ -46,6 +51,14 @@ def run(args):
         logging.getLogger().setLevel(logging.DEBUG)
         logging.info("Verbose output")
 
+    # Create HTTP client with SSL verification setting
+    verify_ssl = not result.no_verify_ssl
+    http_client = HttpClient(verify_ssl=verify_ssl)
+    
+    if not verify_ssl:
+        # Suppress the warnings from urllib3
+        requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+
     # Config
 
     if result.subparsers_name == 'copy-attributes':
@@ -54,7 +67,8 @@ def run(args):
             result.url_source,
             result.url_target,
             result.token_source,
-            result.token_target
+            result.token_target,
+            http_client
         )
         logging.info("<<< copy_attributes")
         return 0
@@ -65,7 +79,8 @@ def run(args):
             result.url_source,
             result.url_target,
             result.token_source,
-            result.token_target
+            result.token_target,
+            http_client
         )
         logging.info("<<< copy_technologies")
         return 0
@@ -78,7 +93,8 @@ def run(args):
             result.token_source,
             result.token_target,
             result.workspace_source,
-            result.workspace_target
+            result.workspace_target,
+            http_client
         )
         logging.info("<<< copy_screens")
         return 0
@@ -87,7 +103,8 @@ def run(args):
         logging.info(">>> delete_attributes")
         delete_attributes(
             result.url,
-            result.token
+            result.token,
+            http_client
         )
         logging.info("<<< delete_attributes")
         return 0
@@ -105,7 +122,8 @@ def run(args):
             result.version_source,
             result.workspace_target,
             result.version_target,
-            result.tag_value
+            result.tag_value,
+            http_client
         )
         logging.info("<<< copy_glossary")
         return 0
@@ -122,7 +140,8 @@ def run(args):
             result.version_source,
             result.workspace_target,
             result.version_target,
-            result.tag_value
+            result.tag_value,
+            http_client
         )
         logging.info("<<< copy_dictionary")
         return 0
@@ -139,7 +158,8 @@ def run(args):
             result.version_source,
             result.workspace_target,
             result.version_target,
-            result.tag_value
+            result.tag_value,
+            http_client
         )
         logging.info("<<< copy_dataprocessings")
         return 0
@@ -156,7 +176,8 @@ def run(args):
             result.version_source,
             result.workspace_target,
             result.version_target,
-            result.tag_value
+            result.tag_value,
+            http_client
         )
         logging.info("<<< copy_usages")
         return 0
@@ -171,7 +192,8 @@ def run(args):
             result.workspace_source,
             result.version_source,
             result.workspace_target,
-            result.version_target
+            result.version_target,
+            http_client
         )
         logging.info("<<< copy_links")
         return 0
@@ -184,7 +206,8 @@ def run(args):
             result.url,
             result.token,
             result.workspace,
-            result.version
+            result.version,
+            http_client
         )
         logging.info("<<< delete_glossary")
         return 0
@@ -196,7 +219,8 @@ def run(args):
             result.url,
             result.token,
             result.workspace,
-            result.version
+            result.version,
+            http_client
         )
         logging.info("<<< delete_dictionary")
         return 0
@@ -208,7 +232,8 @@ def run(args):
             result.url,
             result.token,
             result.workspace,
-            result.version
+            result.version,
+            http_client
         )
         logging.info("<<< delete_dataprocessings")
         return 0
@@ -220,7 +245,8 @@ def run(args):
             result.url,
             result.token,
             result.workspace,
-            result.version
+            result.version,
+            http_client
         )
         logging.info("<<< delete_usages")
         return 0

--- a/toolbox/api/datagalaxy_api.py
+++ b/toolbox/api/datagalaxy_api.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import logging
+from .http_client import HttpClient
 
 logging.basicConfig(level=logging.INFO,
                     format='{asctime} {levelname} {message}',
@@ -12,6 +13,7 @@ logging.basicConfig(level=logging.INFO,
 class DataGalaxyApi:
     url: str
     token: str
+    http_client: HttpClient
 
 
 PATH_SEPARATOR = "\\"

--- a/toolbox/api/datagalaxy_api_attributes.py
+++ b/toolbox/api/datagalaxy_api_attributes.py
@@ -1,6 +1,7 @@
 import logging
 from enum import Enum
 import requests as requests
+from .http_client import HttpClient
 
 
 class AttributeDataType(Enum):
@@ -18,14 +19,15 @@ class AttributeDataType(Enum):
 
 
 class DataGalaxyApiAttributes:
-    def __init__(self, url: str, token: str):
+    def __init__(self, url: str, token: str, http_client: HttpClient):
         self.url = url
         self.token = token
+        self.http_client = http_client
 
     def list(self, data_type: AttributeDataType, only_custom=True) -> list:
         params = {'dataType': data_type.value.lower()}
         headers = {'Authorization': f"Bearer {self.token}"}
-        request = requests.get(f"{self.url}/attributes", params=params, headers=headers)
+        request = self.http_client.get(f"{self.url}/attributes", params=params, headers=headers)
         code = request.status_code
         body_json = request.json()
 
@@ -43,7 +45,7 @@ class DataGalaxyApiAttributes:
     def list_values(self, data_type: str, attribute_key: str) -> list:
         params = {'dataType': data_type.lower(), 'attributeKey': attribute_key}
         headers = {'Authorization': f"Bearer {self.token}"}
-        request = requests.get(f"{self.url}/attributes/values", params=params, headers=headers)
+        request = self.http_client.get(f"{self.url}/attributes/values", params=params, headers=headers)
         code = request.status_code
         body_json = request.json()
 
@@ -59,7 +61,7 @@ class DataGalaxyApiAttributes:
         for bulk in bulks:
             headers = {'Authorization': f"Bearer {self.token}"}
             logging.debug(f"bulk_create - bulk_create(bulk: {bulk})")
-            request = requests.post(f"{self.url}/attributes/bulk", json=bulk, headers=headers)
+            request = self.http_client.post(f"{self.url}/attributes/bulk", json=bulk, headers=headers)
 
             code = request.status_code
             body_json = request.json()
@@ -77,7 +79,7 @@ class DataGalaxyApiAttributes:
 
     def create_attribute(self, attribute: dict) -> dict:
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.post(f"{self.url}/attributes/{attribute['dataType'].lower()}", json=attribute, headers=headers)
+        response = self.http_client.post(f"{self.url}/attributes/{attribute['dataType'].lower()}", json=attribute, headers=headers)
         code = response.status_code
         body_json = response.json()
 
@@ -89,7 +91,7 @@ class DataGalaxyApiAttributes:
     def create_values(self, data_type: str, attribute_key: str, values: list) -> dict:
         headers = {'Authorization': f"Bearer {self.token}"}
         params = {'dataType': data_type.lower(), 'attributeKey': attribute_key}
-        response = requests.post(f"{self.url}/attributes/values", json=values, headers=headers, params=params)
+        response = self.http_client.post(f"{self.url}/attributes/values", json=values, headers=headers, params=params)
         code = response.status_code
         body_json = response.json()
 
@@ -100,7 +102,7 @@ class DataGalaxyApiAttributes:
 
     def update_attribute(self, data_type: str, attribute_key: str, attribute: dict) -> dict:
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.put(f"{self.url}/attributes/{data_type}/{attribute_key}", json=attribute, headers=headers)
+        response = self.http_client.put(f"{self.url}/attributes/{data_type}/{attribute_key}", json=attribute, headers=headers)
         code = response.status_code
         body_json = response.json()
 
@@ -112,7 +114,7 @@ class DataGalaxyApiAttributes:
     def delete_attribute(self, data_type: AttributeDataType, attribute_key: str) -> bool:
         logging.debug(f"delete_attribute- delete_attribute(data_type: {data_type}, attribute_key: {attribute_key})")
         headers = {'Authorization': f"Bearer {self.token}"}
-        request = requests.delete(f"{self.url}/attributes/{data_type}/{attribute_key}", headers=headers)
+        request = self.http_client.delete(f"{self.url}/attributes/{data_type}/{attribute_key}", headers=headers)
         code = request.status_code
         body_json = request.json()
         logging.debug(f"delete_attribute - delete_attribute.response(body_json: {body_json}, code: {code})")

--- a/toolbox/api/datagalaxy_api_modules.py
+++ b/toolbox/api/datagalaxy_api_modules.py
@@ -1,11 +1,12 @@
 import logging
 import requests as requests
 from toolbox.api.datagalaxy_api import build_bulktree, prune_tree, remove_technology_code, create_batches
+from .http_client import HttpClient
 from typing import Optional
 
 
 class DataGalaxyApiModules:
-    def __init__(self, url: str, token: str, workspace: dict, module: str):
+    def __init__(self, url: str, token: str, workspace: dict, module: str, http_client: HttpClient):
         if module not in ["Glossary", "Dictionary", "DataProcessing", "Uses", "Links"]:
             raise Exception('The specified module does not exist.')
         self.module = module
@@ -23,6 +24,7 @@ class DataGalaxyApiModules:
         self.url = url
         self.token = token
         self.workspace = workspace
+        self.http_client = http_client
 
     def list_objects(self, workspace_name: str, include_links=False) -> list:
         version_id = self.workspace['versionId']
@@ -32,7 +34,7 @@ class DataGalaxyApiModules:
         else:
             params['includeAttributes'] = 'true'
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.get(f"{self.url}/{self.route}", params=params, headers=headers)
+        response = self.http_client.get(f"{self.url}/{self.route}", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
         if code != 200:
@@ -45,7 +47,7 @@ class DataGalaxyApiModules:
         while next_page is not None:
             logging.info('Fetching another page from the API...')
             headers = {'Authorization': f"Bearer {self.token}"}
-            response = requests.get(next_page, headers=headers)
+            response = self.http_client.get(next_page, headers=headers)
             body_json = response.json()
             logging.info(
                 f'list_objects - {len(body_json["results"])} objects found on '
@@ -62,7 +64,7 @@ class DataGalaxyApiModules:
         version_id = self.workspace['versionId']
         params = {'versionId': version_id, 'parentId': parent_id, 'includeAttributes': 'true'}
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.get(f"{self.url}/dataProcessingItem", params=params, headers=headers)
+        response = self.http_client.get(f"{self.url}/dataProcessingItem", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
         if code != 200:
@@ -72,7 +74,7 @@ class DataGalaxyApiModules:
         next_page = body_json["next_page"]
         while next_page is not None:
             headers = {'Authorization': f"Bearer {self.token}"}
-            response = requests.get(next_page, headers=headers)
+            response = self.http_client.get(next_page, headers=headers)
             body_json = response.json()
             next_page = body_json["next_page"]
             result = result + body_json['results']
@@ -89,7 +91,7 @@ class DataGalaxyApiModules:
         else:
             params = {'versionId': version_id, 'limit': '5000', 'includeAttributes': 'true', 'parentId': parent_id}
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.get(f"{self.url}/{object_type}", params=params, headers=headers)
+        response = self.http_client.get(f"{self.url}/{object_type}", params=params, headers=headers)
         code = response.status_code
         body_json = response.json()
         if code != 200:
@@ -102,7 +104,7 @@ class DataGalaxyApiModules:
         while next_page is not None:
             logging.info('Fetching another page from the API...')
             headers = {'Authorization': f"Bearer {self.token}"}
-            response = requests.get(next_page, headers=headers)
+            response = self.http_client.get(next_page, headers=headers)
             body_json = response.json()
             logging.info(
                 f'list_children_objects - {len(body_json["results"])} objects found on '
@@ -118,7 +120,7 @@ class DataGalaxyApiModules:
 
         version_id = self.workspace['versionId']
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.get(f"{self.url}/{self.route}/{version_id}/{source_id}/{mode}Keys", headers=headers)
+        response = self.http_client.get(f"{self.url}/{self.route}/{version_id}/{source_id}/{mode}Keys", headers=headers)
         code = response.status_code
         body_json = response.json()
         if code != 200:
@@ -135,7 +137,7 @@ class DataGalaxyApiModules:
 
         version_id = self.workspace['versionId']
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.put(f"{self.url}/{self.route}/{version_id}/{source_id}/{mode}Keys", json=keys, headers=headers)
+        response = self.http_client.put(f"{self.url}/{self.route}/{version_id}/{source_id}/{mode}Keys", json=keys, headers=headers)
         code = response.status_code
         body_json = response.json()
         if 200 <= code < 300:
@@ -149,7 +151,7 @@ class DataGalaxyApiModules:
     def create_source(self, workspace_name: str, source: dict) -> str:
         version_id = self.workspace['versionId']
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.post(f"{self.url}/{self.route}/{version_id}", json=source, headers=headers)
+        response = self.http_client.post(f"{self.url}/{self.route}/{version_id}", json=source, headers=headers)
         code = response.status_code
         body_json = response.json()
         if code != 201:
@@ -178,7 +180,7 @@ class DataGalaxyApiModules:
 
             version_id = self.workspace['versionId']
             headers = {'Authorization': f"Bearer {self.token}"}
-            response = requests.post(f"{self.url}/{self.route}/bulktree/{version_id}", json=bulktree, headers=headers)
+            response = self.http_client.post(f"{self.url}/{self.route}/bulktree/{version_id}", json=bulktree, headers=headers)
             code = response.status_code
             body_json = response.json()
             if 200 <= code < 300:
@@ -204,7 +206,7 @@ class DataGalaxyApiModules:
 
             version_id = self.workspace['versionId']
             headers = {'Authorization': f"Bearer {self.token}"}
-            response = requests.post(f"{self.url}/{self.route}/bulktree/{version_id}", json=bulktree, headers=headers)
+            response = self.http_client.post(f"{self.url}/{self.route}/bulktree/{version_id}", json=bulktree, headers=headers)
             code = response.status_code
             body_json = response.json()
             if 200 <= code < 300:
@@ -220,7 +222,7 @@ class DataGalaxyApiModules:
             return 0
         version_id = self.workspace['versionId']
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.delete(f"{self.url}/{self.route}/bulk/{version_id}",
+        response = self.http_client.delete(f"{self.url}/{self.route}/bulk/{version_id}",
                                    json=ids,
                                    headers=headers)
         code = response.status_code
@@ -236,7 +238,7 @@ class DataGalaxyApiModules:
         for page in links:
             version_id = self.workspace['versionId']
             headers = {'Authorization': f"Bearer {self.token}"}
-            response = requests.post(f"{self.url}/{self.route}/bulktree/{version_id}", json=page,
+            response = self.http_client.post(f"{self.url}/{self.route}/bulktree/{version_id}", json=page,
                                      headers=headers)
             code = response.status_code
             body_json = response.json()

--- a/toolbox/api/datagalaxy_api_screens.py
+++ b/toolbox/api/datagalaxy_api_screens.py
@@ -1,20 +1,22 @@
 import requests as requests
 from typing import Optional
+from .http_client import HttpClient
 
 
 class DataGalaxyApiScreen:
-    def __init__(self, url: str, token: str, workspace: Optional[dict]):
+    def __init__(self, url: str, token: str, workspace: Optional[dict], http_client: HttpClient):
         self.url = url
         self.token = token
         self.workspace = workspace
+        self.http_client = http_client
 
     def list_screens(self) -> list:
         headers = {'Authorization': f"Bearer {self.token}"}
         if self.workspace is None:
-            response = requests.get(f"{self.url}/attributes/screens", headers=headers)
+            response = self.http_client.get(f"{self.url}/attributes/screens", headers=headers)
         else:
             params = {'versionId': self.workspace['versionId']}
-            response = requests.get(f"{self.url}/attributes/screens", headers=headers, params=params)
+            response = self.http_client.get(f"{self.url}/attributes/screens", headers=headers, params=params)
         code = response.status_code
         body_json = response.json()
         if code != 200:
@@ -28,10 +30,10 @@ class DataGalaxyApiScreen:
         type = screen['type'].lower()
         categories = screen['categories']
         if self.workspace is None:
-            response = requests.put(f"{self.url}/attributes/screens/{dataType}/{type}", json=categories, headers=headers)
+            response = self.http_client.put(f"{self.url}/attributes/screens/{dataType}/{type}", json=categories, headers=headers)
         else:
             params = {'versionId': self.workspace['versionId']}
-            response = requests.put(f"{self.url}/attributes/screens/{dataType}/{type}", json=categories, headers=headers, params=params)
+            response = self.http_client.put(f"{self.url}/attributes/screens/{dataType}/{type}", json=categories, headers=headers, params=params)
         code = response.status_code
         body_json = response.json()
         if code != 200:

--- a/toolbox/api/datagalaxy_api_technologies.py
+++ b/toolbox/api/datagalaxy_api_technologies.py
@@ -1,15 +1,17 @@
 import logging
 import requests as requests
+from .http_client import HttpClient
 
 
 class DataGalaxyApiTechnology:
-    def __init__(self, url: str, token: str):
+    def __init__(self, url: str, token: str, http_client: HttpClient):
         self.url = url
         self.token = token
+        self.http_client = http_client
 
     def list_technologies(self) -> list:
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.get(f"{self.url}/technologies", headers=headers)
+        response = self.http_client.get(f"{self.url}/technologies", headers=headers)
         code = response.status_code
         body_json = response.json()
         if code != 200:
@@ -21,7 +23,7 @@ class DataGalaxyApiTechnology:
 
     def insert_technology(self, technology) -> object:
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.post(f"{self.url}/technologies", json=technology, headers=headers)
+        response = self.http_client.post(f"{self.url}/technologies", json=technology, headers=headers)
         code = response.status_code
         body_json = response.json()
         if code != 201:

--- a/toolbox/api/datagalaxy_api_workspaces.py
+++ b/toolbox/api/datagalaxy_api_workspaces.py
@@ -1,15 +1,17 @@
 import requests as requests
 import logging
+from .http_client import HttpClient
 
 
 class DataGalaxyApiWorkspace:
-    def __init__(self, url: str, token: str):
+    def __init__(self, url: str, token: str, http_client: HttpClient):
         self.url = url
         self.token = token
+        self.http_client = http_client
 
     def list_workspaces(self):
         headers = {'Authorization': f"Bearer {self.token}"}
-        response = requests.get(f"{self.url}/workspaces", headers=headers)
+        response = self.http_client.get(f"{self.url}/workspaces", headers=headers)
         code = response.status_code
         body_json = response.json()
         if code == 200:
@@ -36,7 +38,7 @@ class DataGalaxyApiWorkspace:
     def list_versions(self, id_workspace: str) -> dict:
         headers = {'Authorization': f"Bearer {self.token}"}
         params = {'limit': '5000'}
-        response = requests.get(f"{self.url}/workspaces/{id_workspace}/versions", headers=headers, params=params)
+        response = self.http_client.get(f"{self.url}/workspaces/{id_workspace}/versions", headers=headers, params=params)
         code = response.status_code
         body_json = response.json()
         if code == 200:

--- a/toolbox/api/http_client.py
+++ b/toolbox/api/http_client.py
@@ -1,0 +1,41 @@
+"""
+Centralized HTTP client for all DataGalaxy API requests.
+Handles SSL certificate verification configuration for all requests.
+"""
+import requests
+from typing import Optional, Dict, Any
+
+
+class HttpClient:
+    """
+    Centralized HTTP client that wraps requests and manages SSL verification.
+    """
+    
+    def __init__(self, verify_ssl: bool = True):
+        """
+        Initialize the HTTP client.
+        
+        Args:
+            verify_ssl: Whether to verify SSL certificates for HTTPS requests. Defaults to True.
+        """
+        self.verify_ssl = verify_ssl
+        
+    def get(self, url: str, headers: Optional[Dict[str, str]] = None, params: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Make a GET request with SSL verification control."""
+        return requests.get(url, headers=headers, params=params, verify=self.verify_ssl)
+    
+    def post(self, url: str, headers: Optional[Dict[str, str]] = None, json: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Make a POST request with SSL verification control."""
+        return requests.post(url, headers=headers, json=json, params=params, verify=self.verify_ssl)
+    
+    def put(self, url: str, headers: Optional[Dict[str, str]] = None, json: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Make a PUT request with SSL verification control."""
+        return requests.put(url, headers=headers, json=json, params=params, verify=self.verify_ssl)
+    
+    def delete(self, url: str, headers: Optional[Dict[str, str]] = None, json: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Make a DELETE request with SSL verification control."""
+        return requests.delete(url, headers=headers, json=json, params=params, verify=self.verify_ssl)
+    
+    def patch(self, url: str, headers: Optional[Dict[str, str]] = None, json: Optional[Dict[str, Any]] = None, params: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Make a PATCH request with SSL verification control."""
+        return requests.patch(url, headers=headers, json=json, params=params, verify=self.verify_ssl)

--- a/toolbox/commands/copy_attributes.py
+++ b/toolbox/commands/copy_attributes.py
@@ -1,14 +1,16 @@
 import logging
 
 from toolbox.api.datagalaxy_api_attributes import DataGalaxyApiAttributes, custom_attributes, find_duplicates
+from toolbox.api.http_client import HttpClient
 
 
 def copy_attributes(url_source: str,
                     url_target: str,
                     token_source: str,
-                    token_target: str) -> int:
-    attributes_api_source = DataGalaxyApiAttributes(url=url_source, token=token_source)
-    attributes_api_target = DataGalaxyApiAttributes(url=url_target, token=token_target)
+                    token_target: str,
+                    http_client: HttpClient) -> int:
+    attributes_api_source = DataGalaxyApiAttributes(url=url_source, token=token_source, http_client=http_client)
+    attributes_api_target = DataGalaxyApiAttributes(url=url_target, token=token_target, http_client=http_client)
     custom_source_attributes = custom_attributes(attributes_api_source)
     logging.debug(f"copy_attributes - custom_source_attributes: {custom_source_attributes}")
     logging.info(

--- a/toolbox/commands/copy_links.py
+++ b/toolbox/commands/copy_links.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
+from toolbox.api.http_client import HttpClient
 from toolbox.commands.utils import config_workspace
 
 
@@ -12,7 +13,8 @@ def copy_links(url_source: str,
                workspace_source_name: str,
                version_source_name: Optional[str],
                workspace_target_name: str,
-               version_target_name: Optional[str]) -> int:
+               version_target_name: Optional[str],
+               http_client: HttpClient) -> int:
     if token_target is None:
         token_target = token_source
 
@@ -25,7 +27,8 @@ def copy_links(url_source: str,
         url=url_source,
         token=token_source,
         workspace_name=workspace_source_name,
-        version_name=version_source_name
+        version_name=version_source_name,
+        http_client=http_client
     )
     if not source_workspace:
         return 1
@@ -36,7 +39,8 @@ def copy_links(url_source: str,
         url=url_target,
         token=token_target,
         workspace_name=workspace_target_name,
-        version_name=version_target_name
+        version_name=version_target_name,
+        http_client=http_client
     )
     if not target_workspace:
         return 1
@@ -46,25 +50,29 @@ def copy_links(url_source: str,
         url=url_source,
         token=token_source,
         workspace=source_workspace,
-        module="Glossary"
+        module="Glossary",
+        http_client=http_client
     )
     source_dictionary_api = DataGalaxyApiModules(
         url=url_source,
         token=token_source,
         workspace=source_workspace,
-        module="Dictionary"
+        module="Dictionary",
+        http_client=http_client
     )
     source_dataprocessings_api = DataGalaxyApiModules(
         url=url_source,
         token=token_source,
         workspace=source_workspace,
-        module="DataProcessing"
+        module="DataProcessing",
+        http_client=http_client
     )
     source_usages_api = DataGalaxyApiModules(
         url=url_source,
         token=token_source,
         workspace=source_workspace,
-        module="Uses"
+        module="Uses",
+        http_client=http_client
     )
 
     # Find all links in source workspace
@@ -93,7 +101,8 @@ def copy_links(url_source: str,
         url=url_target,
         token=token_target,
         workspace=target_workspace,
-        module="Links"
+        module="Links",
+        http_client=http_client
     )
 
     # Creating links in target workspace

--- a/toolbox/commands/copy_module.py
+++ b/toolbox/commands/copy_module.py
@@ -2,6 +2,7 @@ from typing import Optional
 import logging
 
 from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
+from toolbox.api.http_client import HttpClient
 from toolbox.commands.utils import config_workspace
 
 
@@ -14,7 +15,8 @@ def copy_module(module: str,
                 version_source_name: Optional[str],
                 workspace_target_name: str,
                 version_target_name: Optional[str],
-                tag_value: Optional[str]) -> int:
+                tag_value: Optional[str],
+                http_client: HttpClient) -> int:
     # Tokens
     if token_target is None:
         token_target = token_source
@@ -29,7 +31,8 @@ def copy_module(module: str,
         url=url_source,
         token=token_source,
         workspace_name=workspace_source_name,
-        version_name=version_source_name
+        version_name=version_source_name,
+        http_client=http_client
     )
     if not source_workspace:
         return 1
@@ -40,7 +43,8 @@ def copy_module(module: str,
         url=url_target,
         token=token_target,
         workspace_name=workspace_target_name,
-        version_name=version_target_name
+        version_name=version_target_name,
+        http_client=http_client
     )
     if not target_workspace:
         return 1
@@ -50,7 +54,8 @@ def copy_module(module: str,
         url=url_source,
         token=token_source,
         workspace=source_workspace,
-        module=module
+        module=module,
+        http_client=http_client
     )
 
     # Target module
@@ -58,7 +63,8 @@ def copy_module(module: str,
         url=url_target,
         token=token_target,
         workspace=target_workspace,
-        module=module
+        module=module,
+        http_client=http_client
     )
 
     # Fetch objects from source workspace

--- a/toolbox/commands/copy_screens.py
+++ b/toolbox/commands/copy_screens.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from toolbox.api.datagalaxy_api_screens import DataGalaxyApiScreen
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
+from toolbox.api.http_client import HttpClient
 
 
 def copy_screens(url_source: str,
@@ -10,7 +11,8 @@ def copy_screens(url_source: str,
                  token_source: str,
                  token_target: Optional[str],
                  workspace_source_name: Optional[str],
-                 workspace_target_name: Optional[str]) -> int:
+                 workspace_target_name: Optional[str],
+                 http_client: HttpClient) -> int:
     if token_target is None:
         token_target = token_source
 
@@ -24,7 +26,8 @@ def copy_screens(url_source: str,
         logging.info("copy_screens - Source workspace name given : copying the workspace's screens")
         workspaces_api_on_source_env = DataGalaxyApiWorkspace(
             url=url_source,
-            token=token_source
+            token=token_source,
+            http_client=http_client
         )
         source_workspace = workspaces_api_on_source_env.get_workspace(workspace_source_name)
         if source_workspace is None:
@@ -37,14 +40,15 @@ def copy_screens(url_source: str,
         logging.info("copy_screens - Target workspace name given : writing on workspace's screens")
         workspaces_api_on_target_env = DataGalaxyApiWorkspace(
             url=url_target,
-            token=token_target
+            token=token_target,
+            http_client=http_client
         )
         target_workspace = workspaces_api_on_target_env.get_workspace(workspace_target_name)
         if target_workspace is None:
             raise Exception(f'workspace {workspace_target_name} does not exist')
 
-    source_screens_api = DataGalaxyApiScreen(url=url_source, token=token_source, workspace=source_workspace)
-    target_screens_api = DataGalaxyApiScreen(url=url_target, token=token_target, workspace=target_workspace)
+    source_screens_api = DataGalaxyApiScreen(url=url_source, token=token_source, workspace=source_workspace, http_client=http_client)
+    target_screens_api = DataGalaxyApiScreen(url=url_target, token=token_target, workspace=target_workspace, http_client=http_client)
 
     source_screens = source_screens_api.list_screens()
     target_screens = target_screens_api.list_screens()

--- a/toolbox/commands/copy_technologies.py
+++ b/toolbox/commands/copy_technologies.py
@@ -1,15 +1,17 @@
 import logging
 
 from toolbox.api.datagalaxy_api_technologies import DataGalaxyApiTechnology
+from toolbox.api.http_client import HttpClient
 
 
 def copy_technologies(url_source: str,
                       url_target: str,
                       token_source: str,
-                      token_target: str) -> int:
+                      token_target: str,
+                      http_client: HttpClient) -> int:
 
-    technologies_api_source = DataGalaxyApiTechnology(url=url_source, token=token_source)
-    technologies_api_target = DataGalaxyApiTechnology(url=url_target, token=token_target)
+    technologies_api_source = DataGalaxyApiTechnology(url=url_source, token=token_source, http_client=http_client)
+    technologies_api_target = DataGalaxyApiTechnology(url=url_target, token=token_target, http_client=http_client)
 
     source_technologies = technologies_api_source.list_technologies()
     target_technologies = technologies_api_target.list_technologies()

--- a/toolbox/commands/delete_attributes.py
+++ b/toolbox/commands/delete_attributes.py
@@ -1,10 +1,11 @@
 import logging
 
 from toolbox.api.datagalaxy_api_attributes import DataGalaxyApiAttributes, custom_attributes
+from toolbox.api.http_client import HttpClient
 
 
-def delete_attributes(url: str, token: str) -> bool:
-    attributes_api_target = DataGalaxyApiAttributes(url=url, token=token)
+def delete_attributes(url: str, token: str, http_client: HttpClient) -> bool:
+    attributes_api_target = DataGalaxyApiAttributes(url=url, token=token, http_client=http_client)
     custom_target_attributes = custom_attributes(attributes_api_target)
     logging.info(
         f'delete_attributes - {len(custom_target_attributes)} custom attributes found on clientspace')

--- a/toolbox/commands/delete_module.py
+++ b/toolbox/commands/delete_module.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from toolbox.api.datagalaxy_api_modules import DataGalaxyApiModules
 from toolbox.api.datagalaxy_api import find_root_objects
+from toolbox.api.http_client import HttpClient
 from toolbox.commands.utils import config_workspace
 
 
@@ -9,7 +10,8 @@ def delete_module(module: str,
                   url: str,
                   token: str,
                   workspace_name: str,
-                  version_name: Optional[str]) -> str:
+                  version_name: Optional[str],
+                  http_client: HttpClient) -> str:
 
     # Workspace
     workspace = config_workspace(
@@ -17,7 +19,8 @@ def delete_module(module: str,
         url=url,
         token=token,
         workspace_name=workspace_name,
-        version_name=version_name
+        version_name=version_name,
+        http_client=http_client
     )
     if not workspace:
         return 1
@@ -27,7 +30,8 @@ def delete_module(module: str,
         url=url,
         token=token,
         workspace=workspace,
-        module=module
+        module=module,
+        http_client=http_client
     )
 
     # Fetch objects from source workspace

--- a/toolbox/commands/utils.py
+++ b/toolbox/commands/utils.py
@@ -1,12 +1,14 @@
 import logging
 from typing import Optional
 from toolbox.api.datagalaxy_api_workspaces import DataGalaxyApiWorkspace
+from toolbox.api.http_client import HttpClient
 
 
-def config_workspace(mode: str, url: str, token: str, workspace_name: str, version_name: Optional[str]):
+def config_workspace(mode: str, url: str, token: str, workspace_name: str, version_name: Optional[str], http_client: HttpClient):
     workspaces_api = DataGalaxyApiWorkspace(
         url=url,
-        token=token)
+        token=token,
+        http_client=http_client)
     workspace = workspaces_api.get_workspace(workspace_name)
     if not workspace:
         return None


### PR DESCRIPTION
#### Checklist
<!-- Please follow this template for your PR to be considered-->
- [X] I have read the [Contribution Guide](../blob/main/CONTRIBUTING.md) ;
- [X] I have read the [Contributor License Agreement (CLA)](../blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md) and understand that the submission of this PR will constitute an  electronic signature of my agreement of the terms and conditions of DataGalaxy's CLA ;
- [X] I have added tests that prove my fix is effective or that my feature works ;
- [X] I have added necessary documentation (if appropriate) ;

#### Short description of what this resolves:
Add a global SSL certificate verification parameter for the DataGalaxy Toolbox command-line application. Enabledby default but can be disabled using `--no-verify-ssl` parameter

#### Changes proposed in this pull request:
- Created a Centralized HTTP Client (http_client.py):
  - Wraps all requests library calls
  - Manages SSL verification through a single verify_ssl parameter

- Added Global CLI Parameter:
  - New --no-verify-ssl flag in the main CLI
  - Defaults to SSL verification enabled (secure by default)

- Refactored All API Classes:
  - Updated all 5 API classes to accept and use the HttpClient
  - Updated All Command Functions:

- Documentation:
  - Added the new parameter to the README.md
  - Included clear description and default behavior