### PR TITLE
Target Python 3.11 and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/checkout@v4
     - name: Install dependencies
-      run: pip3 install -r requirements.txt
+      run: python -m pip install -r requirements.txt
     - name: Lint
       run: python -m flake8 .
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
     - name: Test
       run: python -m pytest
   WindowsBuild:
@@ -42,20 +41,19 @@ jobs:
         python-version: ["3.11"]
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/checkout@v4
     - name: Install dependencies
-      run: pip3 install -r requirements.txt
+      run: python -m pip install -r requirements.txt
     - name: Build exe
       run: pyinstaller -n datagalaxy-toolbox --onefile --console toolbox/__main__.py
     - name: Check datagalaxy-toolbox.exe
       run: dist\datagalaxy-toolbox.exe --help
     - name: Publish datagalaxy-toolbox
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: ${{ github.workspace }}/dist/datagalaxy-toolbox.exe
         name: datagalaxy-toolbox
@@ -68,12 +66,12 @@ jobs:
     if: (success() && startsWith(github.ref, 'refs/tags/v'))
     steps:
     - name: Download datagalaxy-toolbox
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: datagalaxy-toolbox
     - name: Test
       run: ./datagalaxy-toolbox.exe --help
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         files: datagalaxy-toolbox.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build Linux
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -39,7 +39,7 @@ jobs:
     name: Build Windows
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ datagalaxy-toolbox.exe delete-usages [-h] --url URL --token TOKEN --workspace WO
 
 The DataGalaxy Toolbox requires:
 
-- Python >= 3.9
+- Python >= 3.11
 
 ### Steps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 flake8==7.3.0
-pytest==8.4.2
-twine==6.2.0
-build==1.4.4
+pytest==9.1.1
+twine==7.0.0
+build==1.5.0
 wheel==0.47.0
-requests==2.32.5
+requests==2.34.2
 pytest-mock==3.15.1
 PyJWT==2.13.0
 pyinstaller==6.21.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(name='toolbox',
       version=__version__,
       author='DataGalaxy',
       author_email='opencode@datagalaxy.com',
-      python_requires='>=3.9',
+      python_requires='>=3.11',
       packages=find_packages(),
-      install_requires=['requests==2.32.5', 'PyJWT==2.13.0']
+      install_requires=['requests==2.34.2', 'PyJWT==2.13.0']
       )

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -111,11 +111,21 @@ def test_http_client_patch_with_ssl_verification_disabled(mocker):
     )
 
 
-def test_http_client_with_valid_ssl_certificate():
+def test_http_client_with_valid_ssl_certificate(mocker):
+    response_mock = mocker.Mock(status_code=200)
+    get_mock = mocker.patch(
+        "toolbox.api.http_client.requests.get",
+        return_value=response_mock,
+    )
     http_client_with_ssl = HttpClient(verify_ssl=True)
-    response = http_client_with_ssl.get("https://httpbingo.org/get")
-    assert response.status_code == 200
+    response = http_client_with_ssl.get(TEST_URL)
 
-    http_client_without_ssl = HttpClient(verify_ssl=False)
-    response = http_client_without_ssl.get("https://httpbingo.org/get")
     assert response.status_code == 200
+    get_mock.assert_called_once_with(TEST_URL, headers=None, params=None, verify=True)
+
+    get_mock.reset_mock()
+    http_client_without_ssl = HttpClient(verify_ssl=False)
+    response = http_client_without_ssl.get(TEST_URL)
+
+    assert response.status_code == 200
+    get_mock.assert_called_once_with(TEST_URL, headers=None, params=None, verify=False)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -71,9 +71,9 @@ def test_http_client_patch_with_ssl_verification_disabled():
 
 def test_http_client_with_valid_ssl_certificate():
     http_client_with_ssl = HttpClient(verify_ssl=True)
-    response = http_client_with_ssl.get("https://httpbin.org/get")
+    response = http_client_with_ssl.get("https://httpbingo.org/get")
     assert response.status_code == 200
 
     http_client_without_ssl = HttpClient(verify_ssl=False)
-    response = http_client_without_ssl.get("https://httpbin.org/get")
+    response = http_client_without_ssl.get("https://httpbingo.org/get")
     assert response.status_code == 200

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -3,70 +3,112 @@ import requests
 from toolbox.api.http_client import HttpClient
 
 
-def test_http_client_with_ssl_verification_enabled():
+TEST_URL = "https://example.com"
+
+
+def test_http_client_with_ssl_verification_enabled(mocker):
+    get_mock = mocker.patch(
+        "toolbox.api.http_client.requests.get",
+        side_effect=requests.exceptions.SSLError,
+    )
     http_client = HttpClient(verify_ssl=True)
 
     with pytest.raises(requests.exceptions.SSLError):
-        http_client.get("https://self-signed.badssl.com/")
+        http_client.get(TEST_URL)
+
+    get_mock.assert_called_once_with(TEST_URL, headers=None, params=None, verify=True)
 
 
-def test_http_client_with_ssl_verification_disabled():
+def test_http_client_with_ssl_verification_disabled(mocker):
+    get_mock = mocker.patch("toolbox.api.http_client.requests.get")
     http_client = HttpClient(verify_ssl=False)
 
-    try:
-        response = http_client.get("https://self-signed.badssl.com/")
-        assert response.status_code in [200, 400, 401, 403, 404, 500]  # Any valid HTTP status
-    except requests.exceptions.SSLError:
-        pytest.fail("SSL error occurred even with SSL verification disabled")
+    response = http_client.get(TEST_URL)
+
+    assert response is get_mock.return_value
+    get_mock.assert_called_once_with(TEST_URL, headers=None, params=None, verify=False)
 
 
-def test_http_client_default_ssl_verification():
+def test_http_client_default_ssl_verification(mocker):
+    get_mock = mocker.patch(
+        "toolbox.api.http_client.requests.get",
+        side_effect=requests.exceptions.SSLError,
+    )
     http_client = HttpClient()
 
     assert http_client.verify_ssl is True
 
     with pytest.raises(requests.exceptions.SSLError):
-        http_client.get("https://self-signed.badssl.com/")
+        http_client.get(TEST_URL)
+
+    get_mock.assert_called_once_with(TEST_URL, headers=None, params=None, verify=True)
 
 
-def test_http_client_post_with_ssl_verification_disabled():
+def test_http_client_post_with_ssl_verification_disabled(mocker):
+    post_mock = mocker.patch("toolbox.api.http_client.requests.post")
+    http_client = HttpClient(verify_ssl=False)
+    payload = {"test": "data"}
+
+    response = http_client.post(TEST_URL, json=payload)
+
+    assert response is post_mock.return_value
+    post_mock.assert_called_once_with(
+        TEST_URL,
+        headers=None,
+        json=payload,
+        params=None,
+        verify=False,
+    )
+
+
+def test_http_client_put_with_ssl_verification_disabled(mocker):
+    put_mock = mocker.patch("toolbox.api.http_client.requests.put")
+    http_client = HttpClient(verify_ssl=False)
+    payload = {"test": "data"}
+
+    response = http_client.put(TEST_URL, json=payload)
+
+    assert response is put_mock.return_value
+    put_mock.assert_called_once_with(
+        TEST_URL,
+        headers=None,
+        json=payload,
+        params=None,
+        verify=False,
+    )
+
+
+def test_http_client_delete_with_ssl_verification_disabled(mocker):
+    delete_mock = mocker.patch("toolbox.api.http_client.requests.delete")
     http_client = HttpClient(verify_ssl=False)
 
-    try:
-        response = http_client.post("https://self-signed.badssl.com/", json={"test": "data"})
-        assert response.status_code in [200, 400, 401, 403, 404, 405, 500]
-    except requests.exceptions.SSLError:
-        pytest.fail("SSL error occurred even with SSL verification disabled")
+    response = http_client.delete(TEST_URL)
+
+    assert response is delete_mock.return_value
+    delete_mock.assert_called_once_with(
+        TEST_URL,
+        headers=None,
+        json=None,
+        params=None,
+        verify=False,
+    )
 
 
-def test_http_client_put_with_ssl_verification_disabled():
+def test_http_client_patch_with_ssl_verification_disabled(mocker):
+    patch_mock = mocker.patch("toolbox.api.http_client.requests.patch")
     http_client = HttpClient(verify_ssl=False)
+    payload = {"test": "data"}
 
-    try:
-        response = http_client.put("https://self-signed.badssl.com/", json={"test": "data"})
-        assert response.status_code in [200, 400, 401, 403, 404, 405, 500]
-    except requests.exceptions.SSLError:
-        pytest.fail("SSL error occurred even with SSL verification disabled")
+    response = http_client.patch(TEST_URL, json=payload)
 
-
-def test_http_client_delete_with_ssl_verification_disabled():
-    http_client = HttpClient(verify_ssl=False)
-
-    try:
-        response = http_client.delete("https://self-signed.badssl.com/")
-        assert response.status_code in [200, 400, 401, 403, 404, 405, 500]
-    except requests.exceptions.SSLError:
-        pytest.fail("SSL error occurred even with SSL verification disabled")
-
-
-def test_http_client_patch_with_ssl_verification_disabled():
-    http_client = HttpClient(verify_ssl=False)
-
-    try:
-        response = http_client.patch("https://self-signed.badssl.com/", json={"test": "data"})
-        assert response.status_code in [200, 400, 401, 403, 404, 405, 500]
-    except requests.exceptions.SSLError:
-        pytest.fail("SSL error occurred even with SSL verification disabled")
+    assert response is patch_mock.return_value
+    patch_mock.assert_called_once_with(
+        TEST_URL,
+        headers=None,
+        json=payload,
+        params=None,
+        verify=False,
+    )
 
 
 def test_http_client_with_valid_ssl_certificate():


### PR DESCRIPTION
## Summary

Move DataGalaxy Toolbox from Python 3.9 to Python 3.11. Python 3.9 is end-of-life, while Python 3.10 reaches end-of-life in October 2026.

## Changes

- require Python 3.11 or newer in package metadata and development documentation
- run Linux and Windows CI jobs on Python 3.11
- update pytest to 9.1.1, twine to 7.0.0, build to 1.5.0, and requests to 2.34.2
- keep the runtime requests pin synchronized between requirements.txt and setup.py
- upgrade checkout, setup-python, CodeQL, artifact, and release actions to their current Node 24 majors
- remove duplicate checkout steps and install dependencies through the selected Python interpreter
- mock successful and failing SSL request paths so HTTP client tests have no third-party service dependency

This supersedes the incompatible dependency update proposed in #104.

## Validation

- all 29 tests passed under Python 3.11
- lint completed under Python 3.11
- PyInstaller produced a working executable and its `--help` smoke test passed